### PR TITLE
Add `parent_type` method

### DIFF
--- a/src/ArrayInterface.jl
+++ b/src/ArrayInterface.jl
@@ -8,6 +8,20 @@ Base.@pure __parameterless_type(T) = Base.typename(T).wrapper
 parameterless_type(x) = parameterless_type(typeof(x))
 parameterless_type(x::Type) = __parameterless_type(x)
 
+"""
+    parent_type(x)
+
+Returns the parent array that `x` wraps.
+"""
+parent_type(x) = parent_type(typeof(x))
+parent_type(::Type{<:SubArray{T,N,P}}) where {T,N,P} = P
+parent_type(::Type{<:Base.ReshapedArray{T,N,P}}) where {T,N,P} = P
+parent_type(::Type{Adjoint{T,S}}) where {T,S} = S
+parent_type(::Type{Transpose{T,S}}) where {T,S} = S
+parent_type(::Type{Symmetric{T,S}}) where {T,S} = S
+parent_type(::Type{<:AbstractTriangular{T,S}}) where {T,S} = S
+parent_type(::Type{T}) where {T} = T
+
 function ismutable end
 
 """

--- a/src/ArrayInterface.jl
+++ b/src/ArrayInterface.jl
@@ -19,7 +19,7 @@ parent_type(::Type{<:Base.ReshapedArray{T,N,P}}) where {T,N,P} = P
 parent_type(::Type{Adjoint{T,S}}) where {T,S} = S
 parent_type(::Type{Transpose{T,S}}) where {T,S} = S
 parent_type(::Type{Symmetric{T,S}}) where {T,S} = S
-parent_type(::Type{<:AbstractTriangular{T,S}}) where {T,S} = S
+parent_type(::Type{<:LinearAlgebra.AbstractTriangular{T,S}}) where {T,S} = S
 parent_type(::Type{T}) where {T} = T
 
 function ismutable end

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -164,7 +164,7 @@ using ArrayInterface: zeromatrix
 @test zeromatrix(rand(4,4,4)) == zeros(4*4*4,4*4*4)
 
 using ArrayInterface: parent_type
-@testset "" begin
+@testset "Parent Type" begin
     x = ones(4, 4)
     @test parent_type(view(x, 1:2, 1:2)) <: typeof(x)
     @test parent_type(reshape(x, 2, :)) <: typeof(x)
@@ -172,4 +172,3 @@ using ArrayInterface: parent_type
     @test parent_type(Symmetric(x)) <: typeof(x)
     @test parent_type(UpperTriangular(x)) <: typeof(x)
 end
-

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -162,3 +162,14 @@ end
 
 using ArrayInterface: zeromatrix
 @test zeromatrix(rand(4,4,4)) == zeros(4*4*4,4*4*4)
+
+using ArrayInterface: parent_type
+@testset "" begin
+    x = ones(4, 4)
+    @test parent_type(view(x, 1:2, 1:2)) <: typeof(x)
+    @test parent_type(reshape(x, 2, :)) <: typeof(x)
+    @test parent_type(transpose(x)) <: typeof(x)
+    @test parent_type(Symmetric(x)) <: typeof(x)
+    @test parent_type(UpperTriangular(x)) <: typeof(x)
+end
+


### PR DESCRIPTION
This adds a method that returns the type of the parent array. The default method is to just return the type of the array itself, which matches `parent`'s behavior.

If this sounds good I'll move forward with writing tests.