### PR TITLE
Added sized range interface.

### DIFF
--- a/README.md
+++ b/README.md
@@ -94,6 +94,23 @@ information is adequately contained in the type for standard tools to work. In
 these cases, `restructure` gives a way to convert for example an `Array` into
 a matching `ArrayPartition`.
 
+## known_first(::Type{T})
+
+If `first` of instances of type `T` are known at compile time, return that first
+element. Otherwise, return `nothing`. For example, `known_first(Base.OneTo{Int})`
+returns `one(Int)`.
+
+## known_last(::Type{T})
+
+If `last` of instances of type `T` are known at compile time, return that
+last element. Otherwise, return `nothing`.
+
+## known_step(::Type{T})
+
+If `step` of instances of type `T` are known at compile time, return that step.
+Otherwise, returns `nothing`. For example, `known_step(UnitRange{Int})` returns
+`one(Int)`.
+
 # List of things to add
 
 - https://github.com/JuliaLang/julia/issues/22216

--- a/src/ArrayInterface.jl
+++ b/src/ArrayInterface.jl
@@ -491,6 +491,38 @@ function restructure(x::Array,y)
   reshape(convert(Array,y),size(x)...)
 end
 
+"""
+known_first(::Type{T})
+
+If `first` of an instance of type `T` is known at compile time, return it.
+Otherwise, return `nothing`.
+
+@test isnothing(known_first(typeof(1:4)))
+@test isone(known_first(typeof(Base.OneTo(4))))
+"""
+known_first(::Any) = nothing
+known_first(::Type{Base.OneTo{T}}) where {T} = one(T)
+"""
+known_last(::Type{T})
+
+If `last` of an instance of type `T` is known at compile time, return it.
+Otherwise, return `nothing`.
+
+@test isnothing(known_last(typeof(1:4)))
+"""
+known_last(::Any) = nothing
+"""
+known_step(::Type{T})
+
+If `step` of an instance of type `T` is known at compile time, return it.
+Otherwise, return `nothing`.
+
+@test isnothing(known_step(typeof(1:0.2:4)))
+@test isone(known_step(typeof(1:4)))
+"""
+known_step(::Any) = nothing
+known_step(::Type{<:AbstractUnitRange{T}}) where {T} = one(T)
+
 function __init__()
 
   @require SuiteSparse="4607b0f0-06f3-5cda-b6b1-a6196a1729e9" begin

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -172,3 +172,14 @@ using ArrayInterface: parent_type
     @test parent_type(Symmetric(x)) <: typeof(x)
     @test parent_type(UpperTriangular(x)) <: typeof(x)
 end
+
+@testset "Range Interface" begin
+    @test isnothing(ArrayInterface.known_first(typeof(1:4)))
+    @test isone(ArrayInterface.known_first(typeof(Base.OneTo(4))))
+    
+    @test isnothing(ArrayInterface.known_last(typeof(1:4)))
+    
+    @test isnothing(ArrayInterface.known_step(typeof(1:0.2:4)))
+    @test isone(ArrayInterface.known_step(typeof(1:4)))
+end
+


### PR DESCRIPTION
As brought up in https://github.com/SciML/ArrayInterface.jl/issues/50

Anything else we should add while at it?

Thoughts on the name and default return (`nothing`)?
I figured `known_` is clear as a prefix for queering values known at compile time.