### PR TITLE
Range traits now work on instance and types

### DIFF
--- a/src/ArrayInterface.jl
+++ b/src/ArrayInterface.jl
@@ -500,8 +500,10 @@ Otherwise, return `nothing`.
 @test isnothing(known_first(typeof(1:4)))
 @test isone(known_first(typeof(Base.OneTo(4))))
 """
-known_first(::Any) = nothing
+known_first(x) = known_first(typeof(x))
+known_first(::Type{T}) where {T} = nothing
 known_first(::Type{Base.OneTo{T}}) where {T} = one(T)
+
 """
 known_last(::Type{T})
 
@@ -512,7 +514,9 @@ Otherwise, return `nothing`.
 using StaticArrays
 @test known_last(typeof(SOneTo(4))) == 4
 """
-known_last(::Any) = nothing
+known_last(x) = known_last(typeof(x))
+known_last(::Type{T}) where {T} = nothing
+
 """
 known_step(::Type{T})
 
@@ -522,7 +526,8 @@ Otherwise, return `nothing`.
 @test isnothing(known_step(typeof(1:0.2:4)))
 @test isone(known_step(typeof(1:4)))
 """
-known_step(::Any) = nothing
+known_step(x) = known_step(typeof(x))
+known_step(::Type{T}) where {T} = nothing
 known_step(::Type{<:AbstractUnitRange{T}}) where {T} = one(T)
 
 function __init__()

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -177,11 +177,14 @@ end
 
 @testset "Range Interface" begin
     @test isnothing(ArrayInterface.known_first(typeof(1:4)))
+    @test isone(ArrayInterface.known_first(Base.OneTo(4)))
     @test isone(ArrayInterface.known_first(typeof(Base.OneTo(4))))
-    
+
+    @test isnothing(ArrayInterface.known_last(1:4))
     @test isnothing(ArrayInterface.known_last(typeof(1:4)))
     
     @test isnothing(ArrayInterface.known_step(typeof(1:0.2:4)))
+    @test isone(ArrayInterface.known_step(1:4))
     @test isone(ArrayInterface.known_step(typeof(1:4)))
 end
 


### PR DESCRIPTION
This makes it so if an instance of a type is passed to `known_first`, `known_step`, or `known_last` then its type is used instead of just returning nothing.