### PR TITLE
New trait for collections that change sizes (issue #22)

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,9 +15,9 @@ and exported in a future Base Julia there will be no issues with the upgrade.
 
 Returns the parent array that `x` wraps.
 
-## is_dynamic(x)
+## can_change_size(x)
 
-Returns `true` if the size of `T` is dynamic. If `T` is dynamic then operations
+Returns `true` if the size of `T` can change, in which case operations
 such as `pop!` and `popfirst!` are available for collections of type `T`.
 
 ## ismutable(x)

--- a/README.md
+++ b/README.md
@@ -11,6 +11,15 @@ serve as a staging ground for ideas before they merged into Base Julia. For this
 reason, no functionality is exported so that way if such functions are added
 and exported in a future Base Julia there will be no issues with the upgrade.
 
+## parent_type(x)
+
+Returns the parent array that `x` wraps.
+
+## is_dynamic(x)
+
+Returns `true` if the size of `T` is dynamic. If `T` is dynamic then operations
+such as `pop!` and `popfirst!` are available for collections of type `T`.
+
 ## ismutable(x)
 
 A trait function for whether `x` is a mutable or immutable array. Used for

--- a/src/ArrayInterface.jl
+++ b/src/ArrayInterface.jl
@@ -23,16 +23,16 @@ parent_type(::Type{<:LinearAlgebra.AbstractTriangular{T,S}}) where {T,S} = S
 parent_type(::Type{T}) where {T} = T
 
 """
-    is_dynamic(::Type{T}) -> Bool
+    can_change_size(::Type{T}) -> Bool
 
-Returns `true` if the size of `T` is dynamic. If `T` is dynamic then operations
+Returns `true` if the size of `T` can change, in which case operations
 such as `pop!` and `popfirst!` are available for collections of type `T`.
 """
-is_dynamic(x) = is_dynamic(typeof(x))
-is_dynamic(::Type{T}) where {T} = false
-is_dynamic(::Type{<:Vector}) = true
-is_dynamic(::Type{<:AbstractDict}) = true
-is_dynamic(::Type{<:Base.ImmutableDict}) = false
+can_change_size(x) = can_change_size(typeof(x))
+can_change_size(::Type{T}) where {T} = false
+can_change_size(::Type{<:Vector}) = true
+can_change_size(::Type{<:AbstractDict}) = true
+can_change_size(::Type{<:Base.ImmutableDict}) = false
 
 function ismutable end
 

--- a/src/ArrayInterface.jl
+++ b/src/ArrayInterface.jl
@@ -22,6 +22,18 @@ parent_type(::Type{Symmetric{T,S}}) where {T,S} = S
 parent_type(::Type{<:LinearAlgebra.AbstractTriangular{T,S}}) where {T,S} = S
 parent_type(::Type{T}) where {T} = T
 
+"""
+    is_dynamic(::Type{T}) -> Bool
+
+Returns `true` if the size of `T` is dynamic. If `T` is dynamic then operations
+such as `pop!` and `popfirst!` are available for collections of type `T`.
+"""
+is_dynamic(x) = is_dynamic(typeof(x))
+is_dynamic(::Type{T}) where {T} = false
+is_dynamic(::Type{<:Vector}) = true
+is_dynamic(::Type{<:AbstractDict}) = true
+is_dynamic(::Type{<:Base.ImmutableDict}) = false
+
 function ismutable end
 
 """

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -182,9 +182,17 @@ end
 
     @test isnothing(ArrayInterface.known_last(1:4))
     @test isnothing(ArrayInterface.known_last(typeof(1:4)))
-    
+
     @test isnothing(ArrayInterface.known_step(typeof(1:0.2:4)))
     @test isone(ArrayInterface.known_step(1:4))
     @test isone(ArrayInterface.known_step(typeof(1:4)))
+end
+
+@testset "is_dynamic" begin
+    @test ArrayInterface.is_dynamic([1])
+    @test ArrayInterface.is_dynamic(Vector{Int})
+    @test ArrayInterface.is_dynamic(Dict{Symbol,Any})
+    @test !ArrayInterface.is_dynamic(Base.ImmutableDict{Symbol,Int64})
+    @test !ArrayInterface.is_dynamic(Tuple{})
 end
 

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -188,11 +188,11 @@ end
     @test isone(ArrayInterface.known_step(typeof(1:4)))
 end
 
-@testset "is_dynamic" begin
-    @test ArrayInterface.is_dynamic([1])
-    @test ArrayInterface.is_dynamic(Vector{Int})
-    @test ArrayInterface.is_dynamic(Dict{Symbol,Any})
-    @test !ArrayInterface.is_dynamic(Base.ImmutableDict{Symbol,Int64})
-    @test !ArrayInterface.is_dynamic(Tuple{})
+@testset "can_change_size" begin
+    @test ArrayInterface.can_change_size([1])
+    @test ArrayInterface.can_change_size(Vector{Int})
+    @test ArrayInterface.can_change_size(Dict{Symbol,Any})
+    @test !ArrayInterface.can_change_size(Base.ImmutableDict{Symbol,Int64})
+    @test !ArrayInterface.can_change_size(Tuple{})
 end
 


### PR DESCRIPTION
Even if you have a mutable structure it might not be able to change sizes. With this PR if `is_dynamic` returns `true` then the following operations should work for a given collection:

* `push!`
* `pushfirst!`
* `pop!`
* `popfirst!`
* `insert!`
* `deleteat!`

I also updated the README with these methods and can bump the version number if this all sounds good.

