### PR TITLE
Safe co-iteration across an axis for 1+ arrays

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,7 +28,6 @@ returned. If any indices are not equal along dimension `d` an error is thrown. A
 tuple may be used to specify a different dimension for each array. If `d` is not
 specified then indices for visiting each index of `x` is returned.
 
-
 ## ismutable(x)
 
 A trait function for whether `x` is a mutable or immutable array. Used for

--- a/README.md
+++ b/README.md
@@ -20,6 +20,15 @@ Returns the parent array that `x` wraps.
 Returns `true` if the size of `T` can change, in which case operations
 such as `pop!` and `popfirst!` are available for collections of type `T`.
 
+## indices(x[, d])
+
+Given an array `x`, this returns the indices along dimension `d`. If `x` is a tuple
+of arrays then the indices corresponding to dimension `d` of all arrays in `x` are
+returned. If any indices are not equal along dimension `d` an error is thrown. A
+tuple may be used to specify a different dimension for each array. If `d` is not
+specified then indices for visiting each index of `x` is returned.
+
+
 ## ismutable(x)
 
 A trait function for whether `x` is a mutable or immutable array. Used for

--- a/src/ArrayInterface.jl
+++ b/src/ArrayInterface.jl
@@ -503,85 +503,6 @@ function restructure(x::Array,y)
   reshape(convert(Array,y),size(x)...)
 end
 
-"""
-known_first(::Type{T})
-
-If `first` of an instance of type `T` is known at compile time, return it.
-Otherwise, return `nothing`.
-
-@test isnothing(known_first(typeof(1:4)))
-@test isone(known_first(typeof(Base.OneTo(4))))
-"""
-known_first(x) = known_first(typeof(x))
-known_first(::Type{T}) where {T} = nothing
-known_first(::Type{Base.OneTo{T}}) where {T} = one(T)
-
-"""
-known_last(::Type{T})
-
-If `last` of an instance of type `T` is known at compile time, return it.
-Otherwise, return `nothing`.
-
-@test isnothing(known_last(typeof(1:4)))
-using StaticArrays
-@test known_last(typeof(SOneTo(4))) == 4
-"""
-known_last(x) = known_last(typeof(x))
-known_last(::Type{T}) where {T} = nothing
-
-"""
-known_step(::Type{T})
-
-If `step` of an instance of type `T` is known at compile time, return it.
-Otherwise, return `nothing`.
-
-@test isnothing(known_step(typeof(1:0.2:4)))
-@test isone(known_step(typeof(1:4)))
-"""
-known_step(x) = known_step(typeof(x))
-known_step(::Type{T}) where {T} = nothing
-known_step(::Type{<:AbstractUnitRange{T}}) where {T} = one(T)
-
-
-"""
-    indices(x[, d]) -> AbstractRange
-
-Given an array `x`, this returns the indices along dimension `d`. If `x` is a tuple
-of arrays then the indices corresponding to dimension `d` of all arrays in `x` are
-returned. If any indices are not equal along dimension `d` an error is thrown. A
-tuple may be used to specify a different dimension for each array. If `d` is not
-specified then indices for visiting each index of `x` is returned.
-"""
-@inline indices(x) = eachindex(x)
-
-indices(x, d) = indices(axes(x, d))
-
-@inline function indices(x::NTuple{N,<:Any}, dim) where {N}
-  inds = indices(first(x), dim)
-  @assert _check_indices(inds, Base.tail(x), dim) "The indices along dimension $dim are not equal for all $x"
-  return inds
-end
-
-@inline function indices(x::NTuple{N,<:Any}, dim::NTuple{N,<:Any}) where {N}
-  ind = indices(first(x), first(dim))
-  @assert _check_indices(ind, Base.tail(x), Base.tail(dim)) "The indices along dimension $dim are not equal for all $x"
-  return ind
-end
-
-@inline function _check_indices(ind, x::Tuple, dim::Tuple)
-  for (x_i, d_i) in zip(x, dim)
-    ind == indices(x_i, d_i) || return false
-  end
-  return true
-end
-
-@inline function _check_indices(ind, x::Tuple, d)
-  for x_i in x
-    ind == indices(x_i, d) || return false
-  end
-  return true
-end
-
 function __init__()
 
   @require SuiteSparse="4607b0f0-06f3-5cda-b6b1-a6196a1729e9" begin
@@ -736,5 +657,7 @@ function __init__()
     end
   end
 end
+
+include("ranges.jl")
 
 end

--- a/src/ArrayInterface.jl
+++ b/src/ArrayInterface.jl
@@ -542,6 +542,46 @@ known_step(x) = known_step(typeof(x))
 known_step(::Type{T}) where {T} = nothing
 known_step(::Type{<:AbstractUnitRange{T}}) where {T} = one(T)
 
+
+"""
+    indices(x[, d]) -> AbstractRange
+
+Given an array `x`, this returns the indices along dimension `d`. If `x` is a tuple
+of arrays then the indices corresponding to dimension `d` of all arrays in `x` are
+returned. If any indices are not equal along dimension `d` an error is thrown. A
+tuple may be used to specify a different dimension for each array. If `d` is not
+specified then indices for visiting each index of `x` is returned.
+"""
+@inline indices(x) = eachindex(x)
+
+indices(x, d) = indices(axes(x, d))
+
+@inline function indices(x::NTuple{N,<:Any}, dim) where {N}
+  inds = indices(first(x), dim)
+  @assert _check_indices(inds, Base.tail(x), dim) "The indices along dimension $dim are not equal for all $x"
+  return inds
+end
+
+@inline function indices(x::NTuple{N,<:Any}, dim::NTuple{N,<:Any}) where {N}
+  ind = indices(first(x), first(dim))
+  @assert _check_indices(ind, Base.tail(x), Base.tail(dim)) "The indices along dimension $dim are not equal for all $x"
+  return ind
+end
+
+@inline function _check_indices(ind, x::Tuple, dim::Tuple)
+  for (x_i, d_i) in zip(x, dim)
+    ind == indices(x_i, d_i) || return false
+  end
+  return true
+end
+
+@inline function _check_indices(ind, x::Tuple, d)
+  for x_i in x
+    ind == indices(x_i, d) || return false
+  end
+  return true
+end
+
 function __init__()
 
   @require SuiteSparse="4607b0f0-06f3-5cda-b6b1-a6196a1729e9" begin

--- a/src/ranges.jl
+++ b/src/ranges.jl
@@ -58,25 +58,25 @@ from other valid indices. Therefore, users should not expect the same checks are
 to ensure construction of a valid `OptionallyStaticUnitRange` as a `UnitRange`.
 """
 struct OptionallyStaticUnitRange{T,F,L} <: AbstractUnitRange{T}
-    start::F
-    stop::L
+  start::F
+  stop::L
 
-    function OptionallyStaticUnitRange{T}(start, stop) where {T<:Real}
-        if _get(start) isa T
-            if _get(stop) isa T
-                return new{T,typeof(start),typeof(stop)}(start, stop)
-            else
-                return OptionallyStaticUnitRange{T}(start, _convert(T, stop))
-            end
-        else
-            return OptionallyStaticUnitRange{T}(_convert(T, start), stop)
-        end
+  function OptionallyStaticUnitRange{T}(start, stop) where {T<:Real}
+    if _get(start) isa T
+      if _get(stop) isa T
+        return new{T,typeof(start),typeof(stop)}(start, stop)
+      else
+        return OptionallyStaticUnitRange{T}(start, _convert(T, stop))
+      end
+    else
+      return OptionallyStaticUnitRange{T}(_convert(T, start), stop)
     end
+  end
 
-    function OptionallyStaticUnitRange(start, stop)
-        T = promote_type(typeof(_get(start)), typeof(_get(stop)))
-        return OptionallyStaticUnitRange{T}(start, stop)
-    end
+  function OptionallyStaticUnitRange(start, stop)
+    T = promote_type(typeof(_get(start)), typeof(_get(stop)))
+    return OptionallyStaticUnitRange{T}(start, stop)
+  end
 end
 
 Base.first(r::OptionallyStaticUnitRange{<:Any,Val{F}}) where {F} = F
@@ -92,11 +92,11 @@ known_step(::Type{<:OptionallyStaticUnitRange{T}}) where {T} = one(T)
 known_last(::Type{<:OptionallyStaticUnitRange{<:Any,<:Any,Val{L}}}) where {L} = L
 
 function Base.isempty(r::OptionallyStaticUnitRange)
-    if known_first(r) === oneunit(eltype(r))
-        return unsafe_isempty_one_to(last(r))
-    else
-        return unsafe_isempty_unit_range(first(r), last(r))
-    end
+  if known_first(r) === oneunit(eltype(r))
+    return unsafe_isempty_one_to(last(r))
+  else
+    return unsafe_isempty_unit_range(first(r), last(r))
+  end
 end
 
 unsafe_isempty_one_to(lst) = lst <= zero(lst)
@@ -108,26 +108,26 @@ unsafe_length_one_to(lst::T) where {T<:Int} = T(lst)
 unsafe_length_one_to(lst::T) where {T} = Integer(lst - zero(lst))
 
 Base.@propagate_inbounds function Base.getindex(r::OptionallyStaticUnitRange, i::Integer)
-    if known_first(r) === oneunit(r)
-        return get_index_one_to(r, i)
-    else
-        return get_index_unit_range(r, i)
-    end
+  if known_first(r) === oneunit(r)
+    return get_index_one_to(r, i)
+  else
+    return get_index_unit_range(r, i)
+  end
 end
 
 @inline function get_index_one_to(r, i)
-    @boundscheck if ((i > 0) & (i <= last(r)))
-        throw(BoundsError(r, i))
-    end
-    return convert(eltype(r), i)
+  @boundscheck if ((i > 0) & (i <= last(r)))
+    throw(BoundsError(r, i))
+  end
+  return convert(eltype(r), i)
 end
 
 @inline function get_index_unit_range(r, i)
-    val = first(r) + (i - 1)
-    @boundscheck if i > 0 && val <= last(r) && val >= first(r)
-        throw(BoundsError(r, i))
-    end
-    return convert(eltype(r), val)
+  val = first(r) + (i - 1)
+  @boundscheck if i > 0 && val <= last(r) && val >= first(r)
+    throw(BoundsError(r, i))
+  end
+  return convert(eltype(r), val)
 end
 
 _try_static(x, y) = Val(x)
@@ -141,7 +141,7 @@ _try_static(::Nothing, ::Nothing) = nothing
 @inline function known_length(::Type{T}) where {T<:AbstractUnitRange}
   fst = known_first(T)
   lst = known_last(T)
-  if stp === nothing || fst === nothing || lst === nothing
+  if fst === nothing || lst === nothing
     return nothing
   else
     if fst === oneunit(eltype(T))
@@ -153,26 +153,26 @@ _try_static(::Nothing, ::Nothing) = nothing
 end
 
 function Base.length(r::OptionallyStaticUnitRange{T}) where {T}
-    if isempty(r)
-        return zero(T)
+  if isempty(r)
+    return zero(T)
+  else
+    if known_one(r) === one(T)
+      return unsafe_length_one_to(last(r))
     else
-        if known_one(r) === one(T)
-            return unsafe_length_one_to(last(r))
-        else
-            return unsafe_length_unit_range(first(r), last(r))
-        end
+      return unsafe_length_unit_range(first(r), last(r))
     end
+  end
 end
 
 function unsafe_length_unit_range(fst::T, lst::T) where {T<:Union{Int,Int64,Int128}}
-    return Base.checked_add(Base.checked_sub(lst, fst), one(T))
+  return Base.checked_add(Base.checked_sub(lst, fst), one(T))
 end
 function unsafe_length_unit_range(fst::T, lst::T) where {T<:Union{UInt,UInt64,UInt128}}
-    return Base.checked_add(lst - fst, one(T))
+  return Base.checked_add(lst - fst, one(T))
 end
 
 """
-    indices(x[, d]) -> AbstractRange
+    indices(x[, d])
 
 Given an array `x`, this returns the indices along dimension `d`. If `x` is a tuple
 of arrays then the indices corresponding to dimension `d` of all arrays in `x` are
@@ -181,12 +181,12 @@ tuple may be used to specify a different dimension for each array. If `d` is not
 specified then indices for visiting each index of `x` is returned.
 """
 @inline function indices(x)
-    inds = eachindex(x)
-    if inds isa AbstractUnitRange{<:Integer}
-        return Base.Slice(inds)
-    else
-        return inds
-    end
+  inds = eachindex(x)
+  if inds isa AbstractUnitRange{<:Integer}
+    return Base.Slice(inds)
+  else
+    return inds
+  end
 end
 
 indices(x, d) = indices(axes(x, d))
@@ -204,11 +204,11 @@ end
 end
 
 @inline function _pick_range(x, y)
-    fst = _try_static(known_first(x), known_first(y))
-    fst = fst === nothing ? first(x) : fst
+  fst = _try_static(known_first(x), known_first(y))
+  fst = fst === nothing ? first(x) : fst
 
-    lst = _try_static(known_last(x), known_last(y))
-    lst = lst === nothing ? last(x) : lst
-    return Base.Slice(OptionallyStaticUnitRange(fst, lst))
+  lst = _try_static(known_last(x), known_last(y))
+  lst = lst === nothing ? last(x) : lst
+  return Base.Slice(OptionallyStaticUnitRange(fst, lst))
 end
 

--- a/src/ranges.jl
+++ b/src/ranges.jl
@@ -1,6 +1,6 @@
 
 """
-known_first(::Type{T})
+    known_first(::Type{T})
 
 If `first` of an instance of type `T` is known at compile time, return it.
 Otherwise, return `nothing`.
@@ -11,9 +11,11 @@ Otherwise, return `nothing`.
 known_first(x) = known_first(typeof(x))
 known_first(::Type{T}) where {T} = nothing
 known_first(::Type{Base.OneTo{T}}) where {T} = one(T)
+known_first(::Type{T}) where {T<:Base.Slice} = known_first(parent_type(T))
+
 
 """
-known_last(::Type{T})
+    known_last(::Type{T})
 
 If `last` of an instance of type `T` is known at compile time, return it.
 Otherwise, return `nothing`.
@@ -24,9 +26,10 @@ using StaticArrays
 """
 known_last(x) = known_last(typeof(x))
 known_last(::Type{T}) where {T} = nothing
+known_last(::Type{T}) where {T<:Base.Slice} = known_last(parent_type(T))
 
 """
-known_step(::Type{T})
+    known_step(::Type{T})
 
 If `step` of an instance of type `T` is known at compile time, return it.
 Otherwise, return `nothing`.
@@ -38,77 +41,134 @@ known_step(x) = known_step(typeof(x))
 known_step(::Type{T}) where {T} = nothing
 known_step(::Type{<:AbstractUnitRange{T}}) where {T} = one(T)
 
-_eltype(::Type{T}) where {T} = T
-_eltype(::Type{Val{V}}) where {V} = typeof(V)
+# add methods to support ArrayInterface
 
-struct OptionallyStaticRange{T<:Integer,F,S,L} <: OrdinalRange{T,T}
-  start::F
-  step::S
-  stop::L
+_get(x) = x
+_get(::Val{V}) where {V} = V
+_convert(::Type{T}, x) where {T} = convert(T, x)
+_convert(::Type{T}, ::Val{V}) where {T,V} = Val(convert(T, V))
 
-  function OptionallyStaticRange(start::F, step::S, stop::L) where {F,S,L}
-      T = promote_type(_eltype(F), _eltype(S), eltype(L))
-      return new{T,F,S,L}(start, step, stop)
-  end
-end
+"""
+    OptionallyStaticUnitRange{T<:Integer}(start, stop) <: OrdinalRange{T,T}
 
-Base.first(r::OptionallyStaticRange{<:Any,Val{F}}) where {F} = F
-Base.first(r::OptionallyStaticRange{<:Any,<:Any}) = getfield(r, :start)
+This range permits diverse representations of arrays to comunicate common information 
+about their indices. Each field may be an integer or `Val(<:Integer)` if it is known
+at compile time. An `OptionallyStaticUnitRange` is intended to be constructed internally
+from other valid indices. Therefore, users should not expect the same checks are used
+to ensure construction of a valid `OptionallyStaticUnitRange`.
+"""
+struct OptionallyStaticUnitRange{T,F,L} <: AbstractUnitRange{T}
+    start::F
+    stop::L
 
-Base.step(r::OptionallyStaticRange{<:Any,<:Any,Val{S}}) where {S} = S
-Base.step(r::OptionallyStaticRange{<:Any,<:Any,<:Any}) = getfield(r, :step)
-
-Base.last(r::OptionallyStaticRange{<:Any,<:Any,<:Any,Val{L}}) where {L} = L
-Base.last(r::OptionallyStaticRange{<:Any,<:Any,<:Any,<:Any}) = getfield(r, :stop)
-
-ArrayInterface.known_first(::OptionallyStaticRange{<:Any,Val{F}}) where {F} = F
-ArrayInterface.known_step(::OptionallyStaticRange{<:Any,<:Any,Val{S}}) where {S} =S
-ArrayInterface.known_last(::OptionallyStaticRange{<:Any,<:Any,<:Any,Val{L}}) where {L} = L
-
-function Base.isempty(r::OptionallyStaticRange)
-    return (first(r) != last(r)) & ((step(r) > zero(step(r))) != (last(r) > first(r)))
-end
-
-@inline function Base.length(r::OptionallyStaticRange{T}) where {T}
-    if isempty(r)
-        return zero(T)
-    else
-        if known_step(r) === oneunit(T)
-            if known_first(r) === oneunit(T)
-                return last(r)
+    function OptionallyStaticUnitRange{T}(start, stop) where {T<:Real}
+        if _get(start) isa T
+            if _get(stop) isa T
+                return new{T,typeof(start),typeof(stop)}(start, stop)
             else
-                return last(r) - first(r) + step(r)
+                return OptionallyStaticUnitRange{T}(start, _convert(T, stop))
             end
         else
-            return Integer(div((last(r) - first(r)) + step(r), step(r)))
+            return OptionallyStaticUnitRange{T}(_convert(T, start), stop)
         end
+    end
+
+    function OptionallyStaticUnitRange(start, stop)
+        T = promote_type(typeof(_get(start)), typeof(_get(stop)))
+        return OptionallyStaticUnitRange{T}(start, stop)
     end
 end
 
+Base.first(r::OptionallyStaticUnitRange{<:Any,Val{F}}) where {F} = F
+Base.first(r::OptionallyStaticUnitRange{<:Any,<:Any}) = r.start
 
-isempty(r::StepRange) =
-    (r.start != r.stop) & ((r.step > zero(r.step)) != (r.stop > r.start))
-isempty(r::AbstractUnitRange) = first(r) > last(r)
-isempty(r::StepRangeLen) = length(r) == 0
-isempty(r::LinRange) = length(r) == 0
+Base.step(r::OptionallyStaticUnitRange{T}) where {T} = oneunit(T)
 
-# add methods to support ArrayInterface
+Base.last(r::OptionallyStaticUnitRange{<:Any,<:Any,Val{L}}) where {L} = L
+Base.last(r::OptionallyStaticUnitRange{<:Any,<:Any,<:Any}) = r.stop
+
+known_first(::Type{<:OptionallyStaticUnitRange{<:Any,Val{F}}}) where {F} = F
+known_step(::Type{<:OptionallyStaticUnitRange{T}}) where {T} = one(T)
+known_last(::Type{<:OptionallyStaticUnitRange{<:Any,<:Any,Val{L}}}) where {L} = L
+
+function Base.isempty(r::OptionallyStaticUnitRange)
+    if known_first(r) === oneunit(eltype(r))
+        return unsafe_isempty_one_to(last(r))
+    else
+        return unsafe_isempty_unit_range(first(r), last(r))
+    end
+end
+
+unsafe_isempty_one_to(lst) = lst <= zero(lst)
+unsafe_isempty_unit_range(fst, lst) = fst > lst
+
+unsafe_isempty_unit_range(fst::T, lst::T) where {T} = Integer(lst - fst + one(T))
+
+unsafe_length_one_to(lst::T) where {T<:Int} = T(lst)
+unsafe_length_one_to(lst::T) where {T} = Integer(lst - zero(lst))
+
+Base.@propagate_inbounds function Base.getindex(r::OptionallyStaticUnitRange, i::Integer)
+    if known_first(r) === oneunit(r)
+        return get_index_one_to(r, i)
+    else
+        return get_index_unit_range(r, i)
+    end
+end
+
+@inline function get_index_one_to(r, i)
+    @boundscheck if ((i > 0) & (i <= last(r)))
+        throw(BoundsError(r, i))
+    end
+    return convert(eltype(r), i)
+end
+
+@inline function get_index_unit_range(r, i)
+    val = first(r) + (i - 1)
+    @boundscheck if i > 0 && val <= last(r) && val >= first(r)
+        throw(BoundsError(r, i))
+    end
+    return convert(eltype(r), val)
+end
 
 _try_static(x, y) = Val(x)
 _try_static(::Nothing, y) = Val(y)
 _try_static(x, ::Nothing) = Val(x)
 _try_static(::Nothing, ::Nothing) = nothing
 
-@inline function _pick_range(x, y)
-    fst = _try_static(known_first(x), known_first(y))
-    fst = fst === nothing ? first(x) : fst
+###
+### length
+###
+@inline function known_length(::Type{T}) where {T<:AbstractUnitRange}
+  fst = known_first(T)
+  lst = known_last(T)
+  if stp === nothing || fst === nothing || lst === nothing
+    return nothing
+  else
+    if fst === oneunit(eltype(T))
+      return unsafe_length_one_to(lst)
+    else
+      return unsafe_length_unit_range(fst, lst)
+    end
+  end
+end
 
-    st = _try_static(known_step(x), known_step(y))
-    st = st === nothing ? step(x) : st
+function Base.length(r::OptionallyStaticUnitRange{T}) where {T}
+    if isempty(r)
+        return zero(T)
+    else
+        if known_one(r) === one(T)
+            return unsafe_length_one_to(last(r))
+        else
+            return unsafe_length_unit_range(first(r), last(r))
+        end
+    end
+end
 
-    lst = _try_static(known_last(x), known_last(y))
-    lst = lst === nothing ? last(x) : lst
-    return OptionallyStaticRange(fst, st, lst)
+function unsafe_length_unit_range(fst::T, lst::T) where {T<:Union{Int,Int64,Int128}}
+    return Base.checked_add(Base.checked_sub(lst, fst), one(T))
+end
+function unsafe_length_unit_range(fst::T, lst::T) where {T<:Union{UInt,UInt64,UInt128}}
+    return Base.checked_add(lst - fst, one(T))
 end
 
 """
@@ -120,7 +180,14 @@ returned. If any indices are not equal along dimension `d` an error is thrown. A
 tuple may be used to specify a different dimension for each array. If `d` is not
 specified then indices for visiting each index of `x` is returned.
 """
-@inline indices(x) = eachindex(x)
+@inline function indices(x)
+    inds = eachindex(x)
+    if inds isa AbstractUnitRange{<:Integer}
+        return Base.Slice(inds)
+    else
+        return inds
+    end
+end
 
 indices(x, d) = indices(axes(x, d))
 
@@ -136,4 +203,12 @@ end
   return reduce(_pick_range, inds)
 end
 
+@inline function _pick_range(x, y)
+    fst = _try_static(known_first(x), known_first(y))
+    fst = fst === nothing ? first(x) : fst
+
+    lst = _try_static(known_last(x), known_last(y))
+    lst = lst === nothing ? last(x) : lst
+    return Base.Slice(OptionallyStaticUnitRange(fst, lst))
+end
 

--- a/src/ranges.jl
+++ b/src/ranges.jl
@@ -1,0 +1,139 @@
+
+"""
+known_first(::Type{T})
+
+If `first` of an instance of type `T` is known at compile time, return it.
+Otherwise, return `nothing`.
+
+@test isnothing(known_first(typeof(1:4)))
+@test isone(known_first(typeof(Base.OneTo(4))))
+"""
+known_first(x) = known_first(typeof(x))
+known_first(::Type{T}) where {T} = nothing
+known_first(::Type{Base.OneTo{T}}) where {T} = one(T)
+
+"""
+known_last(::Type{T})
+
+If `last` of an instance of type `T` is known at compile time, return it.
+Otherwise, return `nothing`.
+
+@test isnothing(known_last(typeof(1:4)))
+using StaticArrays
+@test known_last(typeof(SOneTo(4))) == 4
+"""
+known_last(x) = known_last(typeof(x))
+known_last(::Type{T}) where {T} = nothing
+
+"""
+known_step(::Type{T})
+
+If `step` of an instance of type `T` is known at compile time, return it.
+Otherwise, return `nothing`.
+
+@test isnothing(known_step(typeof(1:0.2:4)))
+@test isone(known_step(typeof(1:4)))
+"""
+known_step(x) = known_step(typeof(x))
+known_step(::Type{T}) where {T} = nothing
+known_step(::Type{<:AbstractUnitRange{T}}) where {T} = one(T)
+
+_eltype(::Type{T}) where {T} = T
+_eltype(::Type{Val{V}}) where {V} = typeof(V)
+
+struct OptionallyStaticRange{T<:Integer,F,S,L} <: OrdinalRange{T,T}
+  start::F
+  step::S
+  stop::L
+
+  function OptionallyStaticRange(start::F, step::S, stop::L) where {F,S,L}
+      T = promote_type(_eltype(F), _eltype(S), eltype(L))
+      return new{T,F,S,L}(start, step, stop)
+  end
+end
+
+Base.first(r::OptionallyStaticRange{<:Any,Val{F}}) where {F} = F
+Base.first(r::OptionallyStaticRange{<:Any,<:Any}) = getfield(r, :start)
+
+Base.step(r::OptionallyStaticRange{<:Any,<:Any,Val{S}}) where {S} = S
+Base.step(r::OptionallyStaticRange{<:Any,<:Any,<:Any}) = getfield(r, :step)
+
+Base.last(r::OptionallyStaticRange{<:Any,<:Any,<:Any,Val{L}}) where {L} = L
+Base.last(r::OptionallyStaticRange{<:Any,<:Any,<:Any,<:Any}) = getfield(r, :stop)
+
+ArrayInterface.known_first(::OptionallyStaticRange{<:Any,Val{F}}) where {F} = F
+ArrayInterface.known_step(::OptionallyStaticRange{<:Any,<:Any,Val{S}}) where {S} =S
+ArrayInterface.known_last(::OptionallyStaticRange{<:Any,<:Any,<:Any,Val{L}}) where {L} = L
+
+function Base.isempty(r::OptionallyStaticRange)
+    return (first(r) != last(r)) & ((step(r) > zero(step(r))) != (last(r) > first(r)))
+end
+
+@inline function Base.length(r::OptionallyStaticRange{T}) where {T}
+    if isempty(r)
+        return zero(T)
+    else
+        if known_step(r) === oneunit(T)
+            if known_first(r) === oneunit(T)
+                return last(r)
+            else
+                return last(r) - first(r) + step(r)
+            end
+        else
+            return Integer(div((last(r) - first(r)) + step(r), step(r)))
+        end
+    end
+end
+
+
+isempty(r::StepRange) =
+    (r.start != r.stop) & ((r.step > zero(r.step)) != (r.stop > r.start))
+isempty(r::AbstractUnitRange) = first(r) > last(r)
+isempty(r::StepRangeLen) = length(r) == 0
+isempty(r::LinRange) = length(r) == 0
+
+# add methods to support ArrayInterface
+
+_try_static(x, y) = Val(x)
+_try_static(::Nothing, y) = Val(y)
+_try_static(x, ::Nothing) = Val(x)
+_try_static(::Nothing, ::Nothing) = nothing
+
+@inline function _pick_range(x, y)
+    fst = _try_static(known_first(x), known_first(y))
+    fst = fst === nothing ? first(x) : fst
+
+    st = _try_static(known_step(x), known_step(y))
+    st = st === nothing ? step(x) : st
+
+    lst = _try_static(known_last(x), known_last(y))
+    lst = lst === nothing ? last(x) : lst
+    return OptionallyStaticRange(fst, st, lst)
+end
+
+"""
+    indices(x[, d]) -> AbstractRange
+
+Given an array `x`, this returns the indices along dimension `d`. If `x` is a tuple
+of arrays then the indices corresponding to dimension `d` of all arrays in `x` are
+returned. If any indices are not equal along dimension `d` an error is thrown. A
+tuple may be used to specify a different dimension for each array. If `d` is not
+specified then indices for visiting each index of `x` is returned.
+"""
+@inline indices(x) = eachindex(x)
+
+indices(x, d) = indices(axes(x, d))
+
+@inline function indices(x::NTuple{N,<:Any}, dim) where {N}
+  inds = map(x_i -> indices(x_i, dim), x)
+  @assert all(isequal(first(inds)), Base.tail(inds)) "Not all specified axes are equal: $inds"
+  return reduce(_pick_range, inds)
+end
+
+@inline function indices(x::NTuple{N,<:Any}, dim::NTuple{N,<:Any}) where {N}
+  inds = map(indices, x, dim)
+  @assert all(isequal(first(inds)), Base.tail(inds)) "Not all specified axes are equal: $inds"
+  return reduce(_pick_range, inds)
+end
+
+

--- a/src/ranges.jl
+++ b/src/ranges.jl
@@ -55,7 +55,7 @@ This range permits diverse representations of arrays to comunicate common inform
 about their indices. Each field may be an integer or `Val(<:Integer)` if it is known
 at compile time. An `OptionallyStaticUnitRange` is intended to be constructed internally
 from other valid indices. Therefore, users should not expect the same checks are used
-to ensure construction of a valid `OptionallyStaticUnitRange`.
+to ensure construction of a valid `OptionallyStaticUnitRange` as a `UnitRange`.
 """
 struct OptionallyStaticUnitRange{T,F,L} <: AbstractUnitRange{T}
     start::F

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -10,6 +10,7 @@ using StaticArrays
 @test ArrayInterface.ismutable((0.1,1.0)) == false
 @test isone(ArrayInterface.known_first(typeof(StaticArrays.SOneTo(7))))
 @test ArrayInterface.known_last(typeof(StaticArrays.SOneTo(7))) == 7
+@test ArrayInterface.known_length(typeof(StaticArrays.SOneTo(7))) == 7
 
 using LinearAlgebra, SparseArrays
 
@@ -173,6 +174,8 @@ using ArrayInterface: parent_type
     @test parent_type(transpose(x)) <: typeof(x)
     @test parent_type(Symmetric(x)) <: typeof(x)
     @test parent_type(UpperTriangular(x)) <: typeof(x)
+    @test parent_type(PermutedDimsArray(x, (2,1))) <: typeof(x)
+    @test parent_type(Base.Slice(1:10)) <: UnitRange{Int}
 end
 
 @testset "Range Interface" begin
@@ -194,6 +197,13 @@ end
     @test ArrayInterface.can_change_size(Dict{Symbol,Any})
     @test !ArrayInterface.can_change_size(Base.ImmutableDict{Symbol,Int64})
     @test !ArrayInterface.can_change_size(Tuple{})
+end
+
+@testset "known_length" begin
+    @test ArrayInterface.known_length(ArrayInterface.indices(SOneTo(7))) == 7
+    @test ArrayInterface.known_length(1:2) == nothing
+    @test ArrayInterface.known_length((1,)) == 1
+    @test ArrayInterface.known_length((a=1,b=2)) == 2
 end
 
 @testset "indices" begin

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -196,3 +196,12 @@ end
     @test !ArrayInterface.can_change_size(Tuple{})
 end
 
+@testset "indices" begin
+    @test @inferred(ArrayInterface.indices(ones(2, 3))) == 1:6
+    @test @inferred(ArrayInterface.indices(ones(2, 3), 1)) == 1:2
+    @test @inferred(ArrayInterface.indices((ones(2, 3), ones(3, 2)), (1, 2))) == 1:2
+    @test @inferred(ArrayInterface.indices((ones(2, 3), ones(2, 3)), 1)) == 1:2
+    @test_throws AssertionError ArrayInterface.indices((ones(2, 3), ones(3, 3)), 1)
+    @test_throws AssertionError ArrayInterface.indices((ones(2, 3), ones(3, 3)), (1, 2))
+end
+

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -207,6 +207,7 @@ end
 end
 
 @testset "indices" begin
+    @test @inferred(ArrayInterface.indices((ones(2, 3), ones(3, 2)))) == 1:6
     @test @inferred(ArrayInterface.indices(ones(2, 3))) == 1:6
     @test @inferred(ArrayInterface.indices(ones(2, 3), 1)) == 1:2
     @test @inferred(ArrayInterface.indices((ones(2, 3), ones(3, 2)), (1, 2))) == 1:2


### PR DESCRIPTION
This should help with #62. The main idea is that we can get the convenience of checking compatible indices like in `eachindex(A...)`, but for specific axes. Possible concerns may be:

1. I decided to have `indices(x)` always return iterable indices instead of a tuple of indices. So the default behavior is like `eachindex`. This does two things for us:
    1. The behavior of `for i in indices(args...) ... end` is more predictable becaues `i` can always point to a single value of the array(s).
    2. It makes it very easy to incorporate/extend for other array/array-like types. If the behavior is unique to each axis then only `indices(x)` needs to be specified. If the behavior is unique for the array then only `indices(x, i)` needs to be specified.
2. I didn't implement any special behavior for combining/optimizing known range first/last/step although it was mentioned in #62. I figured even a minimal range type would be meaty enough for an independent PR. 

If people don't find the first point compelling enough to depart from behavior like `axes` I can change it. I just thought it was a really interesting idea. I'm also happy to implement a range if it's seen as immediately necessary for this PR.