### PR TITLE
Fix stack overflow bug in known_length

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,6 +1,6 @@
 name = "ArrayInterface"
 uuid = "4fba245c-0d91-5ea0-9b3e-6abc04ee57a9"
-version = "2.12.0"
+version = "2.12.1"
 
 [deps]
 LinearAlgebra = "37e2e46d-f89d-539d-b4ee-838fcccc9c8e"

--- a/src/ArrayInterface.jl
+++ b/src/ArrayInterface.jl
@@ -36,7 +36,7 @@ known_length(x) = known_length(typeof(x))
 known_length(::Type{<:NTuple{N,<:Any}}) where {N} = N
 known_length(::Type{<:NamedTuple{L}}) where {L} = length(L)
 known_length(::Type{T}) where {T<:Base.Slice} = known_length(parent_type(T))
-known_length(::Type{T}) where {T} = false
+known_length(::Type{T}) where {T} = nothing
 
 """
     can_change_size(::Type{T}) -> Bool

--- a/src/ArrayInterface.jl
+++ b/src/ArrayInterface.jl
@@ -36,6 +36,7 @@ known_length(x) = known_length(typeof(x))
 known_length(::Type{<:NTuple{N,<:Any}}) where {N} = N
 known_length(::Type{<:NamedTuple{L}}) where {L} = length(L)
 known_length(::Type{T}) where {T<:Base.Slice} = known_length(parent_type(T))
+known_length(::Type{T}) where {T} = false
 
 """
     can_change_size(::Type{T}) -> Bool

--- a/src/ArrayInterface.jl
+++ b/src/ArrayInterface.jl
@@ -35,8 +35,19 @@ Otherwise, return `nothing`.
 known_length(x) = known_length(typeof(x))
 known_length(::Type{<:NTuple{N,<:Any}}) where {N} = N
 known_length(::Type{<:NamedTuple{L}}) where {L} = length(L)
-known_length(::Type{T}) where {T<:Base.Slice} = known_length(parent_type(T))
-known_length(::Type{T}) where {T} = nothing
+known_length(::Type{<:Number}) = 1
+function known_length(::Type{T}) where {T}
+    if parent_type(T) <: T
+        return nothing
+    else
+        return known_length(parent_type(T))
+    end
+end
+@inline function known_length(::Type{<:SubArray{T,N,P,I}}) where {T,N,P,I}
+    return _known_length(ntuple(i -> known_length(I.parameters[i]), Val(N)))
+end
+_known_length(x::Tuple{Vararg{<:Union{Int,Nothing}}}) = nothing
+_known_length(x::Tuple{Vararg{Int}}) = prod(x)
 
 """
     can_change_size(::Type{T}) -> Bool

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -205,6 +205,10 @@ end
     @test ArrayInterface.known_length((1,)) == 1
     @test ArrayInterface.known_length((a=1,b=2)) == 2
     @test ArrayInterface.known_length([]) == nothing
+
+    x = view(SArray{Tuple{3,3,3}}(ones(3,3,3)), :, SOneTo(2), 2)
+    @test @inferred(ArrayInterface.known_length(x)) == 6
+    @test @inferred(ArrayInterface.known_length(x')) == 6
 end
 
 @testset "indices" begin

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -204,6 +204,7 @@ end
     @test ArrayInterface.known_length(1:2) == nothing
     @test ArrayInterface.known_length((1,)) == 1
     @test ArrayInterface.known_length((a=1,b=2)) == 2
+    @test ArrayInterface.known_length([]) == nothing
 end
 
 @testset "indices" begin


### PR DESCRIPTION
Added default `known_length(::Type{T}) where {T} = nothing`