### PR TITLE
Fix #53 with ismutable default

### DIFF
--- a/src/ArrayInterface.jl
+++ b/src/ArrayInterface.jl
@@ -72,9 +72,10 @@ https://github.com/JuliaDiffEq/RecursiveArrayTools.jl/issues/19.
 ismutable(x) = ismutable(typeof(x))
 
 ismutable(::Type{<:AbstractArray}) = true
-ismutable(::Type{<:Number}) = false
 ismutable(::Type{<:AbstractRange}) = false
-ismutable(::Type{<:Tuple}) = false
+ismutable(::Type{<:AbstractDict}) = true
+ismutable(::Type{<:Base.ImmutableDict}) = false
+ismutable(::Type{T}) where {T} = T.mutable
 
 # Piracy
 function Base.setindex(x::AbstractArray,v,i...)

--- a/src/ArrayInterface.jl
+++ b/src/ArrayInterface.jl
@@ -71,11 +71,23 @@ https://github.com/JuliaDiffEq/RecursiveArrayTools.jl/issues/19.
 """
 ismutable(x) = ismutable(typeof(x))
 
-ismutable(::Type{<:AbstractArray}) = true
+function ismutable(::Type{T}) where {T<:AbstractArray}
+    if parent_type(T) <: T
+        return true
+    else
+        return ismutable(parent_type(T))
+    end
+end
 ismutable(::Type{<:AbstractRange}) = false
 ismutable(::Type{<:AbstractDict}) = true
 ismutable(::Type{<:Base.ImmutableDict}) = false
-ismutable(::Type{T}) where {T} = T.mutable
+function ismutable(::Type{T}) where {T}
+    if parent_type(T) <: T
+        return T.mutable
+    else
+        return ismutable(parent_type(T))
+    end
+end
 
 # Piracy
 function Base.setindex(x::AbstractArray,v,i...)

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -4,12 +4,17 @@ import ArrayInterface: has_sparsestruct, findstructralnz, fast_scalar_indexing, 
 @test ArrayInterface.ismutable(rand(3))
 
 using StaticArrays
-@test ArrayInterface.ismutable(@SVector [1,2,3]) == false
-@test ArrayInterface.ismutable(@MVector [1,2,3]) == true
+x = @SVector [1,2,3]
+@test ArrayInterface.ismutable(x) == false
+@test ArrayInterface.ismutable(view(x, 1:2)) == false
+x = @MVector [1,2,3]
+@test ArrayInterface.ismutable(x) == true
+@test ArrayInterface.ismutable(view(x, 1:2)) == true
 @test ArrayInterface.ismutable(1:10) == false
 @test ArrayInterface.ismutable((0.1,1.0)) == false
 @test ArrayInterface.ismutable(Base.ImmutableDict{Symbol,Int64}) == false
 @test ArrayInterface.ismutable((;x=1)) == false
+
 @test isone(ArrayInterface.known_first(typeof(StaticArrays.SOneTo(7))))
 @test ArrayInterface.known_last(typeof(StaticArrays.SOneTo(7))) == 7
 @test ArrayInterface.known_length(typeof(StaticArrays.SOneTo(7))) == 7

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -8,6 +8,8 @@ using StaticArrays
 @test ArrayInterface.ismutable(@MVector [1,2,3]) == true
 @test ArrayInterface.ismutable(1:10) == false
 @test ArrayInterface.ismutable((0.1,1.0)) == false
+@test ArrayInterface.ismutable(Base.ImmutableDict{Symbol,Int64}) == false
+@test ArrayInterface.ismutable((;x=1)) == false
 @test isone(ArrayInterface.known_first(typeof(StaticArrays.SOneTo(7))))
 @test ArrayInterface.known_last(typeof(StaticArrays.SOneTo(7))) == 7
 @test ArrayInterface.known_length(typeof(StaticArrays.SOneTo(7))) == 7
@@ -46,6 +48,7 @@ rowind,colind=findstructralnz(Sp)
 
 @test ArrayInterface.ismutable(spzeros(1, 1))
 @test ArrayInterface.ismutable(spzeros(1))
+
 
 @test !fast_scalar_indexing(qr(rand(10, 10)).Q)
 @test !fast_scalar_indexing(qr(rand(10, 10), Val(true)).Q)


### PR DESCRIPTION
This makes it so that `ismutable` has a default now, which is to use the `mutable` field of a type.