### PR TITLE
Non-mutating versions of pop, popfirst, etc. (#66)

### DIFF
--- a/src/ArrayInterface.jl
+++ b/src/ArrayInterface.jl
@@ -551,14 +551,12 @@ Return a new instance of `collection` with `item` inserted into at the given `in
 Base.@propagate_inbounds function insert(collection, index, item)
   @boundscheck checkbounds(collection, index)
   ret = similar(collection, length(collection) + 1)
-  @inbounds for i in indices(ret)
-    if i < index
+  @inbounds for i in firstindex(ret):(index - 1)
       ret[i] = collection[i]
-    elseif i == index
-      ret[i] = item
-    else
+  end
+  @inbounds ret[index] = item
+  @inbounds for i in (index + 1):lastindex(ret)
       ret[i] = collection[i - 1]
-    end
   end
   return ret
 end

--- a/src/ArrayInterface.jl
+++ b/src/ArrayInterface.jl
@@ -543,6 +543,79 @@ function restructure(x::Array,y)
   reshape(convert(Array,y),size(x)...)
 end
 
+"""
+    push(collection, item)
+
+Return a new instance of `collection` with `item` inserted on the end.
+"""
+push(collection, x) = vcat(collection, x)
+
+"""
+    pushfirst(collection, item)
+
+Return a new instance of `collection` with `item` inserted at the beginning.
+"""
+pushfirst(collection, x) = vcat(x, collection)
+
+"""
+    insert(collection, index, item)
+
+Return a new instance of `collection` with `item` inserted into at the given `index`.
+"""
+Base.@propagate_inbounds function insert(collection, index, item)
+  @boundscheck checkbounds(collection, index)
+  ret = similar(collection, length(collection) + 1)
+  @inbounds for i in indices(ret)
+    if i < index
+      ret[i] = collection[i]
+    elseif i == index
+      ret[i] = item
+    else
+      ret[i] = collection[i - 1]
+    end
+  end
+  return ret
+end
+
+"""
+    pop(collection)
+
+Return a new instance of `collection` with the last item removed.
+"""
+@inline function pop(collection)
+  inds = pop(indices(collection))
+  return @inbounds(getindex(collection, inds))
+end
+
+"""
+    popfirst(collection)
+
+
+Return a new instance of `collection` with the first item removed.
+"""
+@inline function popfirst(collection)
+  inds = popfirst(indices(collection))
+  return @inbounds(getindex(collection, inds))
+end
+
+"""
+    deleteat(collection, index)
+
+Return a new instance of `collection` with the item at the given `index` removed.
+"""
+Base.@propagate_inbounds function deleteat(collection, index)
+  @boundscheck checkbounds(collection, index)
+  ret = similar(collection, length(collection) - 1)
+  @inbounds for i in indices(ret)
+    if i < index
+      ret[i] = collection[i]
+    else
+      ret[i] = collection[i + 1]
+    end
+  end
+  return ret
+end
+
 function __init__()
 
   @require SuiteSparse="4607b0f0-06f3-5cda-b6b1-a6196a1729e9" begin

--- a/src/ranges.jl
+++ b/src/ranges.jl
@@ -232,19 +232,4 @@ end
   return Base.Slice(OptionallyStaticUnitRange(fst, lst))
 end
 
-function pop(r::AbstractUnitRange)
-    if isempty(r)
-        throw(ArgumentError("cannot pop value from empty collection"))
-    else
-        return (static_first(r)):(static_last(r) - Static(1))
-    end
-end
-
-function popfirst(r::AbstractUnitRange)
-    if isempty(r)
-        throw(ArgumentError("cannot pop value from empty collection"))
-    else
-        return (static_first(r) + Static(1)):static_last(r)
-    end
-end
-
+indices(::Tuple{Vararg{Any,N}}) where {N} = OptionallyStaticUnitRange(Static(1), Static(N))

--- a/src/ranges.jl
+++ b/src/ranges.jl
@@ -183,7 +183,7 @@ function Base.length(r::OptionallyStaticUnitRange{T}) where {T}
   end
 end
 
-unsafe_length_unit_range(fst::T, lst::T) where {T} = Integer(lst - fst + one(T))
+unsafe_length_unit_range(fst, lst) = Integer(lst - fst + 1)
 function unsafe_length_unit_range(fst::T, lst::T) where {T<:Union{Int,Int64,Int128}}
   return Base.checked_add(Base.checked_sub(lst, fst), one(T))
 end
@@ -236,21 +236,7 @@ function pop(r::AbstractUnitRange)
     if isempty(r)
         throw(ArgumentError("cannot pop value from empty collection"))
     else
-        start = known_first(r)
-        stop = known_last(r)
-        if start === nothing
-            if stop === nothing
-                return first(r):(last(r) - 1)
-            else
-                return OptionallyStaticUnitRange(first(r), Val(stop - 1))
-            end
-        else
-            if stop === nothing
-                return OptionallyStaticUnitRange(Val(start), last(r) - 1)
-            else
-                return OptionallyStaticUnitRange(Val(start), Val(stop - 1))
-            end
-        end
+        return (static_first(r)):(static_last(r) - Static(1))
     end
 end
 
@@ -258,21 +244,7 @@ function popfirst(r::AbstractUnitRange)
     if isempty(r)
         throw(ArgumentError("cannot pop value from empty collection"))
     else
-        start = known_first(r)
-        stop = known_last(r)
-        if start === nothing
-            if stop === nothing
-                return (first(r) + 1):last(r)
-            else
-                return OptionallyStaticUnitRange(first(r) + 1, Val(stop))
-            end
-        else
-            if stop === nothing
-                return OptionallyStaticUnitRange(Val(start + 1), last(r))
-            else
-                return OptionallyStaticUnitRange(Val(start + 1), Val(stop))
-            end
-        end
+        return (static_first(r) + Static(1)):static_last(r)
     end
 end
 

--- a/src/ranges.jl
+++ b/src/ranges.jl
@@ -171,9 +171,7 @@ function Base.length(r::OptionallyStaticUnitRange)
   end
 end
 
-function unsafe_length_unit_range(start, stop)
-  return Base.checked_add(Base.checked_sub(start, stop), one(T))
-end
+unsafe_length_unit_range(start::Integer, stop::Integer) = Int(start - stop + 1)
 
 """
     indices(x[, d])

--- a/src/static.jl
+++ b/src/static.jl
@@ -33,6 +33,7 @@ end
 Base.promote_rule(::Type{<:Static}, ::Type{<:Static}) = Int
 Base.:(%)(::Static{N}, ::Type{Integer}) where {N} = N
 
+Base.eltype(::Type{T}) where {T<:Static} = Int
 Base.iszero(::Static{0}) = true
 Base.iszero(::Static) = false
 Base.isone(::Static{1}) = true

--- a/src/static.jl
+++ b/src/static.jl
@@ -7,8 +7,8 @@ struct Static{N} <: Integer
     Static{N}() where {N} = new{N::Int}()
 end
 
-const Zero = Static{0}()
-const One = Static{1}()
+const Zero = Static{0}
+const One = Static{1}
 
 Base.@pure Static(N::Int) = Static{N}()
 Static(N::Integer) = Static(convert(Int, N))
@@ -38,43 +38,43 @@ Base.promote_rule(::Type{<:Static}, ::Type{<:Static}) = Int
 Base.:(%)(::Static{N}, ::Type{Integer}) where {N} = N
 
 Base.eltype(::Type{T}) where {T<:Static} = Int
-Base.iszero(::Static{0}) = true
+Base.iszero(::Zero) = true
 Base.iszero(::Static) = false
-Base.isone(::Static{1}) = true
+Base.isone(::One) = true
 Base.isone(::Static) = false
-Base.zero(::Type{T}) where {T<:Static} = Zero
-Base.one(::Type{T}) where {T<:Static} = One
+Base.zero(::Type{T}) where {T<:Static} = Zero()
+Base.one(::Type{T}) where {T<:Static} = One()
 
 for T = [:Real, :Rational, :Integer]
     @eval begin
-        @inline Base.:(+)(i::$T, ::Static{0}) = i
+        @inline Base.:(+)(i::$T, ::Zero) = i
         @inline Base.:(+)(i::$T, ::Static{M}) where {M} = i + M
-        @inline Base.:(+)(::Static{0}, i::$T) = i
+        @inline Base.:(+)(::Zero, i::$T) = i
         @inline Base.:(+)(::Static{M}, i::$T) where {M} = M + i
-        @inline Base.:(-)(i::$T, ::Static{0}) = i
+        @inline Base.:(-)(i::$T, ::Zero) = i
         @inline Base.:(-)(i::$T, ::Static{M}) where {M} = i - M
-        @inline Base.:(*)(i::$T, ::Static{0}) = Static{0}()
-        @inline Base.:(*)(i::$T, ::Static{1}) = i
+        @inline Base.:(*)(i::$T, ::Zero) = Zero()
+        @inline Base.:(*)(i::$T, ::One) = i
         @inline Base.:(*)(i::$T, ::Static{M}) where {M} = i * M
-        @inline Base.:(*)(::Static{0}, i::$T) = Static{0}()
-        @inline Base.:(*)(::Static{1}, i::$T) = i
+        @inline Base.:(*)(::Zero, i::$T) = Zero()
+        @inline Base.:(*)(::One, i::$T) = i
         @inline Base.:(*)(::Static{M}, i::$T) where {M} = M * i
     end
 end
-@inline Base.:(+)(::Static{0}, ::Static{0}) = Static{0}()
-@inline Base.:(+)(::Static{0}, ::Static{M}) where {M} = Static{M}()
-@inline Base.:(+)(::Static{M}, ::Static{0}) where {M} = Static{M}()
+@inline Base.:(+)(::Zero, ::Zero) = Zero()
+@inline Base.:(+)(::Zero, ::Static{M}) where {M} = Static{M}()
+@inline Base.:(+)(::Static{M}, ::Zero) where {M} = Static{M}()
 
-@inline Base.:(-)(::Static{M}, ::Static{0}) where {M} = Static{M}()
+@inline Base.:(-)(::Static{M}, ::Zero) where {M} = Static{M}()
 
-@inline Base.:(*)(::Static{0}, ::Static{0}) = Static{0}()
-@inline Base.:(*)(::Static{1}, ::Static{0}) = Static{0}()
-@inline Base.:(*)(::Static{0}, ::Static{1}) = Static{0}()
-@inline Base.:(*)(::Static{1}, ::Static{1}) = Static{1}()
-@inline Base.:(*)(::Static{M}, ::Static{0}) where {M} = Static{0}()
-@inline Base.:(*)(::Static{0}, ::Static{M}) where {M} = Static{0}()
-@inline Base.:(*)(::Static{M}, ::Static{1}) where {M} = Static{M}()
-@inline Base.:(*)(::Static{1}, ::Static{M}) where {M} = Static{M}()
+@inline Base.:(*)(::Zero, ::Zero) = Zero()
+@inline Base.:(*)(::One, ::Zero) = Zero()
+@inline Base.:(*)(::Zero, ::One) = Zero()
+@inline Base.:(*)(::One, ::One) = One()
+@inline Base.:(*)(::Static{M}, ::Zero) where {M} = Zero()
+@inline Base.:(*)(::Zero, ::Static{M}) where {M} = Zero()
+@inline Base.:(*)(::Static{M}, ::One) where {M} = Static{M}()
+@inline Base.:(*)(::One, ::Static{M}) where {M} = Static{M}()
 for f ∈ [:(+), :(-), :(*), :(/), :(÷), :(%), :(<<), :(>>), :(>>>), :(&), :(|), :(⊻)]
     @eval @generated Base.$f(::Static{M}, ::Static{N}) where {M,N} = Expr(:call, Expr(:curly, :Static, $f(M, N)))
 end

--- a/src/static.jl
+++ b/src/static.jl
@@ -6,6 +6,10 @@ Use `Static(N)` instead of `Val(N)` when you want it to behave like a number.
 struct Static{N} <: Integer
     Static{N}() where {N} = new{N::Int}()
 end
+
+const Zero = Static{0}()
+const One = Static{1}()
+
 Base.@pure Static(N::Int) = Static{N}()
 Static(N::Integer) = Static(convert(Int, N))
 Static(::Static{N}) where {N} = Static{N}()
@@ -38,8 +42,8 @@ Base.iszero(::Static{0}) = true
 Base.iszero(::Static) = false
 Base.isone(::Static{1}) = true
 Base.isone(::Static) = false
-Base.zero(::Type{T}) where {T<:Static} = Static{0}()
-Base.one(::Type{T}) where {T<:Static} = Static{1}()
+Base.zero(::Type{T}) where {T<:Static} = Zero
+Base.one(::Type{T}) where {T<:Static} = One
 
 for T = [:Real, :Rational, :Integer]
     @eval begin

--- a/src/static.jl
+++ b/src/static.jl
@@ -37,6 +37,8 @@ Base.iszero(::Static{0}) = true
 Base.iszero(::Static) = false
 Base.isone(::Static{1}) = true
 Base.isone(::Static) = false
+Base.zero(::Type{T}) where {T<:Static} = Static{0}()
+Base.one(::Type{T}) where {T<:Static} = Static{1}()
 
 for T = [:Real, :Rational, :Integer]
     @eval begin

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -272,11 +272,11 @@ end
 end
 
 @testset "push, pushfirst, pop, popfirst, insert, deleteat" begin
-    @test ArrayInterface.push([1,2,3], 4) == [1, 2, 3, 4]
-    @test ArrayInterface.pushfirst([2,3,4], 1) == [1, 2, 3, 4]
-    @test ArrayInterface.pop([1, 2, 3, 4]) == [1, 2, 3]
-    @test ArrayInterface.popfirst([1, 2, 3, 4]) == [2, 3, 4]
-    @test ArrayInterface.insert([1,2,3], 2, -2) == [1, -2, 2, 3]
-    @test ArrayInterface.deleteat([1, 2, 3], 2) == [1, 3]
+    @test @inferred(ArrayInterface.push([1,2,3], 4)) == [1, 2, 3, 4]
+    @test @inferred(ArrayInterface.pushfirst([2,3,4], 1)) == [1, 2, 3, 4]
+    @test @inferred(ArrayInterface.pop([1, 2, 3, 4])) == [1, 2, 3]
+    @test @inferred(ArrayInterface.popfirst([1, 2, 3, 4])) == [2, 3, 4]
+    @test @inferred(ArrayInterface.insert([1,2,3], 2, -2)) == [1, -2, 2, 3]
+    @test @inferred(ArrayInterface.deleteat([1, 2, 3], 2)) == [1, 3]
 end
 

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -252,6 +252,8 @@ end
 @testset "Static" begin
     @test iszero(Static(0))
     @test !iszero(Static(1))
+    @test @inferred(one(Static)) === Static(1)
+    @test @inferred(zero(Static)) === Static(0)
     # test for ambiguities and correctness
     for i ∈ [Static(0), Static(1), Static(2), 3]
         for j ∈ [Static(0), Static(1), Static(2), 3]

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -254,6 +254,7 @@ end
     @test !iszero(Static(1))
     @test @inferred(one(Static)) === Static(1)
     @test @inferred(zero(Static)) === Static(0)
+    @test eltype(one(Static)) <: Int
     # test for ambiguities and correctness
     for i ∈ [Static(0), Static(1), Static(2), 3]
         for j ∈ [Static(0), Static(1), Static(2), 3]
@@ -274,11 +275,21 @@ end
 end
 
 @testset "push, pushfirst, pop, popfirst, insert, deleteat" begin
-    @test @inferred(ArrayInterface.push([1,2,3], 4)) == [1, 2, 3, 4]
-    @test @inferred(ArrayInterface.pushfirst([2,3,4], 1)) == [1, 2, 3, 4]
-    @test @inferred(ArrayInterface.pop([1, 2, 3, 4])) == [1, 2, 3]
-    @test @inferred(ArrayInterface.popfirst([1, 2, 3, 4])) == [2, 3, 4]
     @test @inferred(ArrayInterface.insert([1,2,3], 2, -2)) == [1, -2, 2, 3]
     @test @inferred(ArrayInterface.deleteat([1, 2, 3], 2)) == [1, 3]
+
+    @test @inferred(ArrayInterface.deleteat([1, 2, 3], [1, 2])) == [3]
+    @test @inferred(ArrayInterface.deleteat([1, 2, 3], [1, 3])) == [2]
+    @test @inferred(ArrayInterface.deleteat([1, 2, 3], [2, 3])) == [1]
+
+
+    @test @inferred(ArrayInterface.insert((1,2,3), 1, -2)) == (-2, 1, 2, 3)
+    @test @inferred(ArrayInterface.insert((1,2,3), 2, -2)) == (1, -2, 2, 3)
+    @test @inferred(ArrayInterface.insert((1,2,3), 3, -2)) == (1, 2, -2, 3)
+
+    @test @inferred(ArrayInterface.deleteat((1, 2, 3), 1)) == (2, 3)
+    @test @inferred(ArrayInterface.deleteat((1, 2, 3), 2)) == (1, 3)
+    @test @inferred(ArrayInterface.deleteat((1, 2, 3), 3)) == (1, 2)
+    @test ArrayInterface.deleteat((1, 2, 3), [1, 2]) == (3,)
 end
 

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -274,7 +274,7 @@ end
     end
 end
 
-@testset "push, pushfirst, pop, popfirst, insert, deleteat" begin
+@testset "insert/deleteat" begin
     @test @inferred(ArrayInterface.insert([1,2,3], 2, -2)) == [1, -2, 2, 3]
     @test @inferred(ArrayInterface.deleteat([1, 2, 3], 2)) == [1, 3]
 

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -229,3 +229,12 @@ end
     @test_throws AssertionError ArrayInterface.indices((ones(2, 3), ones(3, 3)), (1, 2))
 end
 
+@testset "push, pushfirst, pop, popfirst, insert, deleteat" begin
+    @test ArrayInterface.push([1,2,3], 4) == [1, 2, 3, 4]
+    @test ArrayInterface.pushfirst([2,3,4], 1) == [1, 2, 3, 4]
+    @test ArrayInterface.pop([1, 2, 3, 4]) == [1, 2, 3]
+    @test ArrayInterface.popfirst([1, 2, 3, 4]) == [2, 3, 4]
+    @test ArrayInterface.insert([1,2,3], 2, -2) == [1, -2, 2, 3]
+    @test ArrayInterface.deleteat([1, 2, 3], 2) == [1, 3]
+end
+


### PR DESCRIPTION
Some of this would be a lot cleaner if the `Static` type from #61 were available, but it's at least a start at creating generic versions for #66. 