### PR TITLE
Additional StaticInt constructor

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,6 +1,6 @@
 name = "ArrayInterface"
 uuid = "4fba245c-0d91-5ea0-9b3e-6abc04ee57a9"
-version = "2.13.1"
+version = "2.13.2"
 
 [deps]
 LinearAlgebra = "37e2e46d-f89d-539d-b4ee-838fcccc9c8e"

--- a/src/static.jl
+++ b/src/static.jl
@@ -16,6 +16,7 @@ StaticInt(::StaticInt{N}) where {N} = StaticInt{N}()
 StaticInt(::Val{N}) where {N} = StaticInt{N}()
 # Base.Val(::StaticInt{N}) where {N} = Val{N}()
 Base.convert(::Type{T}, ::StaticInt{N}) where {T<:Number,N} = convert(T, N)
+(::Type{T})(x) where {T<:StaticInt} = StaticInt(x)
 # (::Type{T})(::ArrayInterface.StaticInt{N}) where {T,N} = T(N)
 Base.convert(::Type{StaticInt{N}}, ::StaticInt{N}) where {N} = StaticInt{N}()
 

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -400,6 +400,8 @@ end
 @testset "Static" begin
     @test iszero(StaticInt(0))
     @test !iszero(StaticInt(1))
+    @test @inferred(one(StaticInt(1))) === StaticInt(1)
+    @test @inferred(zero(StaticInt(1))) === StaticInt(0)
     @test @inferred(one(StaticInt)) === StaticInt(1)
     @test @inferred(zero(StaticInt)) === StaticInt(0)
     @test eltype(one(StaticInt)) <: Int


### PR DESCRIPTION
Every once in a while some method will call `typeof(x)(::Integer)` where `x` is an integer. This needs to be explicitly supported for `StaticInt` b/c of the static parameter.