### PR TITLE
Formalize interface for keyword arguments in indexing

### DIFF
--- a/src/ArrayInterface.jl
+++ b/src/ArrayInterface.jl
@@ -11,7 +11,7 @@ parameterless_type(x) = parameterless_type(typeof(x))
 parameterless_type(x::Type) = __parameterless_type(x)
 
 """
-    parent_type(x)
+    parent_type(::Type{T})
 
 Returns the parent array that `x` wraps.
 """

--- a/src/ArrayInterface.jl
+++ b/src/ArrayInterface.jl
@@ -889,6 +889,7 @@ end
 
 include("static.jl")
 include("ranges.jl")
+include("dimensions.jl")
 include("indexing.jl")
 include("stridelayout.jl")
 

--- a/src/dimensions.jl
+++ b/src/dimensions.jl
@@ -49,6 +49,13 @@ end
 end
 
 """
+    named_axes(x) -> NamedTuple{dimnames(x)}(axes(x))
+
+Returns a `NamedTuple` of the axes of `x` with dimension names as keys.
+"""
+named_axes(x) = NamedTuple{dimnames(x)}(axes(x))
+
+"""
     to_dims(x, d)
 
 This returns the dimension(s) of `x` corresponding to `d`.
@@ -116,4 +123,35 @@ order_named_inds(val::Val{L}; kw...) where {L} = order_named_inds(val, kw.data)
         return Expr(:tuple, exs...)
     end
 end
+
+"""
+  size(A)
+
+Returns the size of `A`. If the size of any axes are known at compile time,
+these should be returned as `Static` numbers. For example:
+```julia
+julia> using StaticArrays, ArrayInterface
+
+julia> A = @SMatrix rand(3,4);
+
+julia> ArrayInterface.size(A)
+(StaticInt{3}(), StaticInt{4}())
+```
+"""
+size(A) = Base.size(A)
+size(A, d) = size(A)[to_dims(A, d)]
+
+"""
+    axes(A, d)
+
+Return a valid range that maps to each index along dimension `d` of `A`.
+"""
+axes(A, d) = axes(A)[to_dims(A, d)]
+
+"""
+    axes(A)
+
+Return a tuple of ranges where each range maps to each element along a dimension of `A`.
+"""
+axes(A) = Base.axes(A)
 

--- a/src/dimensions.jl
+++ b/src/dimensions.jl
@@ -1,0 +1,117 @@
+
+"""
+    has_dimnames(x) -> Bool
+
+Returns `true` if `x` has names for each dimension.
+"""
+@inline has_dimnames(x) = has_dimnames(typeof(x))
+function has_dimnames(::Type{T}) where {T}
+    if parent_type(T) <: T
+        return false
+    else
+        return has_dimnames(parent_type(T))
+    end
+end
+
+@generated default_dimnames(::Val{N}) where {N} = :($(ntuple(i -> Symbol(:dim_, i), N)))
+
+"""
+    dimnames(x) -> Tuple
+
+Return the names of the dimensions for `x`.
+"""
+@inline dimnames(x) = dimnames(typeof(x))
+function dimnames(::Type{T}) where {T}
+    if parent_type(T) <: T
+        return default_dimnames(Val(ndims(T)))
+    else
+        return dimnames(parent_type(T))
+    end
+end
+dimnames(::Type{T}) where {T<:Transpose} = reverse(dimnames(parent_type(T)))
+dimnames(::Type{T}) where {T<:Adjoint} = reverse(dimnames(parent_type(T)))
+@inline function dimnames(::Type{T}) where {I1,A,T<:PermutedDimsArray{<:Any,<:Any,I1,<:Any,A}}
+    ns = dimnames(A)
+    return map(i -> getfield(ns, i), I1)
+end
+@generated function dimnames(::Type{T}) where {N,A,I,T<:SubArray{<:Any,N,A,I}}
+    e = Expr(:tuple)
+    d = dimnames(A)
+    for i in 1:N
+        if argdims(A, I.parameters[i]) > 0
+            push!(e.args, d[i])
+        end
+    end
+    return e
+end
+
+"""
+    to_dims(x, d)
+
+This returns the dimension(s) of `x` corresponding to `d`.
+"""
+to_dims(x, d::Integer) = Int(d)
+to_dims(x, d::StaticInt) = d
+to_dims(x, d::Colon) = d   # `:` is the default for most methods that take `dims`
+@inline to_dims(x, d::Tuple) = map(i -> to_dims(x, i), d)
+@inline function to_dims(x, d::Symbol)::Int
+    i = _sym_to_dim(dimnames(x), d)
+    if i === 0
+        throw(ArgumentError("Specified name ($(repr(d))) does not match any dimension name ($(dimnames(x)))"))
+    end
+    return i
+end
+Base.@pure function _sym_to_dim(x::Tuple{Vararg{Symbol,N}}, sym::Symbol) where {N}
+    for i in 1:N
+        getfield(x, i) === sym && return i
+    end
+    return 0
+end
+
+"""
+    tuple_issubset
+
+A version of `issubset` sepecifically for `Tuple`s of `Symbol`s, that is `@pure`.
+This helps it get optimised out of existance. It is less of an abuse of `@pure` than
+most of the stuff for making `NamedTuples` work.
+"""
+Base.@pure function tuple_issubset(
+    lhs::Tuple{Vararg{Symbol,N}}, rhs::Tuple{Vararg{Symbol,M}},
+) where {N,M}
+    N <= M || return false
+    for a in lhs
+        found = false
+        for b in rhs
+            found |= a === b
+        end
+        found || return false
+    end
+    return true
+end
+
+"""
+    order_named_inds(Val(names); kw...)
+    order_named_inds(Val(names), namedtuple)
+
+Returns the tuple of index values for an array with `names`, when indexed by keywords.
+Any dimensions not fixed are given as `:`, to make a slice.
+An error is thrown if any keywords are used which do not occur in `nda`'s names.
+"""
+order_named_inds(val::Val{L}; kw...) where {L} = order_named_inds(val, kw.data)
+@generated function order_named_inds(val::Val{L}, ni::NamedTuple{K}) where {L,K}
+    if length(K) === 0
+        return ()  # if kwargs were empty
+    else
+        tuple_issubset(K, L) || throw(DimensionMismatch("Expected subset of $L, got $K"))
+        exs = map(L) do n
+            if Base.sym_in(n, K)
+                qn = QuoteNode(n)
+                :(getfield(ni, $qn))
+            else
+                :(Colon())
+            end
+        end
+        return Expr(:tuple, exs...)
+    end
+end
+

--- a/src/indexing.jl
+++ b/src/indexing.jl
@@ -390,6 +390,7 @@ Changing indexing based on a given argument from `args` should be done through
 [`flatten_args`](@ref), [`to_index`](@ref), or [`to_axis`](@ref).
 """
 @propagate_inbounds getindex(A, args...) = unsafe_getindex(A, to_indices(A, args))
+@propagate_inbounds getindex(A; kwargs...) = A[order_named_inds(Val(dimnames(A)); kwargs...)...]
 
 """
     unsafe_getindex(A, inds)
@@ -490,6 +491,10 @@ Store the given values at the given key or index within a collection.
               "elements after construction.")
     end
 end
+@propagate_inbounds function setindex!(A, val; kwargs...)
+    A[order_named_inds(Val(dimnames(A)); kwargs...)...] = val
+end
+
 
 """
     unsafe_setindex!(A, val, inds::Tuple)
@@ -530,3 +535,4 @@ Sets `inds` of `A` to `val`. `inds` is assumed to have been bounds-checked.
 @inline function unsafe_set_collection!(A, val, inds)
     return Base._unsafe_setindex!(IndexStyle(A), A, val, inds...)
 end
+

--- a/src/indexing.jl
+++ b/src/indexing.jl
@@ -385,7 +385,7 @@ end
     ArrayInterface.getindex(A, args...)
 
 Retrieve the value(s) stored at the given key or index within a collection. Creating
-anothe instance of `ArrayInterface.getindex` should only be done by overloading `A`.
+another instance of `ArrayInterface.getindex` should only be done by overloading `A`.
 Changing indexing based on a given argument from `args` should be done through
 [`flatten_args`](@ref), [`to_index`](@ref), or [`to_axis`](@ref).
 """

--- a/src/indexing.jl
+++ b/src/indexing.jl
@@ -385,7 +385,7 @@ end
     ArrayInterface.getindex(A, args...)
 
 Retrieve the value(s) stored at the given key or index within a collection. Creating
-another instance of `ArrayInterface.getindex` should only be done by overloading `A`.
+anothe instance of `ArrayInterface.getindex` should only be done by overloading `A`.
 Changing indexing based on a given argument from `args` should be done through
 [`flatten_args`](@ref), [`to_index`](@ref), or [`to_axis`](@ref).
 """
@@ -584,9 +584,9 @@ end
 function _generate_unsafe_setindex!_body(N::Int)
     quote
         x′ = Base.unalias(A, x)
-        @nexprs $N d->(I_d = Base.unalias(A, I[d]))
+        Base.Cartesian.@nexprs $N d->(I_d = Base.unalias(A, I[d]))
         idxlens = Base.Cartesian.@ncall $N Base.index_lengths I
-        @ncall $N Base.setindex_shape_check x′ (d->idxlens[d])
+        Base.Cartesian.@ncall $N Base.setindex_shape_check x′ (d->idxlens[d])
         Xy = iterate(x′)
         @inbounds Base.Cartesian.@nloops $N i d->I_d begin
             # This is never reached, but serves as an assumption for

--- a/src/ranges.jl
+++ b/src/ranges.jl
@@ -433,3 +433,4 @@ end
   lst = _try_static(static_last(x), static_last(y))
   return Base.Slice(OptionallyStaticUnitRange(fst, lst))
 end
+

--- a/src/ranges.jl
+++ b/src/ranges.jl
@@ -9,9 +9,14 @@ Otherwise, return `nothing`.
 @test isone(known_first(typeof(Base.OneTo(4))))
 """
 known_first(x) = known_first(typeof(x))
-known_first(::Type{T}) where {T} = nothing
+function known_first(::Type{T}) where {T}
+    if parent_type(T) <: T
+        return nothing
+    else
+        return known_first(parent_type(T))
+    end
+end
 known_first(::Type{Base.OneTo{T}}) where {T} = one(T)
-known_first(::Type{T}) where {T<:Base.Slice} = known_first(parent_type(T))
 
 """
     known_last(::Type{T})
@@ -24,8 +29,13 @@ using StaticArrays
 @test known_last(typeof(SOneTo(4))) == 4
 """
 known_last(x) = known_last(typeof(x))
-known_last(::Type{T}) where {T} = nothing
-known_last(::Type{T}) where {T<:Base.Slice} = known_last(parent_type(T))
+function known_last(::Type{T}) where {T}
+    if parent_type(T) <: T
+        return nothing
+    else
+        return known_last(parent_type(T))
+    end
+end
 
 """
     known_step(::Type{T})
@@ -37,10 +47,14 @@ Otherwise, return `nothing`.
 @test isone(known_step(typeof(1:4)))
 """
 known_step(x) = known_step(typeof(x))
-known_step(::Type{T}) where {T} = nothing
+function known_step(::Type{T}) where {T}
+    if parent_type(T) <: T
+        return nothing
+    else
+        return known_step(parent_type(T))
+    end
+end
 known_step(::Type{<:AbstractUnitRange{T}}) where {T} = one(T)
-
-# add methods to support ArrayInterface
 
 """
     OptionallyStaticUnitRange(start, stop) <: AbstractUnitRange{Int}

--- a/src/stridelayout.jl
+++ b/src/stridelayout.jl
@@ -9,7 +9,13 @@ If no axis is contiguous, it returns `Contiguous{-1}`.
 If unknown, it returns `nothing`.
 """
 contiguous_axis(x) = contiguous_axis(typeof(x))
-contiguous_axis(::Type) = nothing
+function contiguous_axis(::Type{T}) where {T}
+    if parent_type(T) <: T
+        return nothing
+    else
+        return contiguous_axis(parent_type(T))
+    end
+end
 contiguous_axis(::Type{<:Array}) = Contiguous{1}()
 contiguous_axis(::Type{<:Tuple}) = Contiguous{1}()
 function contiguous_axis(::Type{<:Union{Transpose{T,A},Adjoint{T,A}}}) where {T,A<:AbstractVector{T}}

--- a/src/stridelayout.jl
+++ b/src/stridelayout.jl
@@ -226,21 +226,6 @@ permute(t::NTuple{N}, I::NTuple{N,Int}) where {N} = ntuple(n -> t[I[n]], Val{N}(
 end
 
 """
-  size(A)
-
-Returns the size of `A`. If the size of any axes are known at compile time,
-these should be returned as `Static` numbers. For example:
-```julia
-julia> using StaticArrays, ArrayInterface
-
-julia> A = @SMatrix rand(3,4);
-
-julia> ArrayInterface.size(A)
-(StaticInt{3}(), StaticInt{4}())
-```
-"""
-size(A) = Base.size(A)
-"""
   strides(A)
 
 Returns the strides of array `A`. If any strides are known at compile time,
@@ -253,6 +238,8 @@ julia> ArrayInterface.strides(A)
 ```
 """
 strides(A) = Base.strides(A)
+strides(A, d) = strides(A)[to_dims(A, d)]
+
 """
   offsets(A)
 
@@ -278,7 +265,6 @@ end
         Base.Cartesian.@ntuple $N n -> offsets(A, n)
     end
 end
-
 
 @inline size(B::Union{Transpose{T,A},Adjoint{T,A}}) where {T,A<:AbstractMatrix{T}} = permute(size(parent(B)), Val{(2,1)}())
 @inline size(B::PermutedDimsArray{T,N,I1,I2,A}) where {T,N,I1,I2,A<:AbstractArray{T,N}} = permute(size(parent(B)), Val{I1}())
@@ -314,3 +300,4 @@ end
     end
     Expr(:block, Expr(:meta, :inline), t)
 end
+

--- a/test/dimensions.jl
+++ b/test/dimensions.jl
@@ -5,7 +5,7 @@ struct NamedDimsWrapper{L,T,N,P<:AbstractArray{T,N}} <: AbstractArray{T,N}
     parent::P
     NamedDimsWrapper{L}(p) where {L} = new{L,eltype(p),ndims(p),typeof(p)}(p)
 end
-ArrayInterface.parent_type(::Type{T}) where {P,T<:NamedDimsWrapper{<:Any,P}} = P
+ArrayInterface.parent_type(::Type{T}) where {P,T<:NamedDimsWrapper{<:Any,<:Any,<:Any,P}} = P
 ArrayInterface.has_dimnames(::Type{T}) where {T<:NamedDimsWrapper} = true
 ArrayInterface.dimnames(::Type{T}) where {L,T<:NamedDimsWrapper{L}} = L
 Base.parent(x::NamedDimsWrapper) = x.parent
@@ -48,7 +48,7 @@ dnums = ntuple(+, length(d))
 
 @test @inferred(ArrayInterface.size(x, :x)) == size(parent(x), 1)
 @test @inferred(ArrayInterface.axes(x, :x)) == axes(parent(x), 1)
-@test @inferred(ArrayInterface.strides(x, :x)) == strides(parent(x))[1]
+@test ArrayInterface.strides(x, :x) == ArrayInterface.strides(parent(x))[1]
 
 x[x = 1] = [2, 3]
 @test @inferred(getindex(x, x = 1)) == [2, 3]

--- a/test/dimensions.jl
+++ b/test/dimensions.jl
@@ -1,0 +1,60 @@
+
+@testset "dimensions" begin
+
+struct NamedDimsWrapper{L,T,N,P<:AbstractArray{T,N}} <: AbstractArray{T,N}
+    parent::P
+    NamedDimsWrapper{L}(p) where {L} = new{L,eltype(p),ndims(p),typeof(p)}(p)
+end
+ArrayInterface.parent_type(::Type{T}) where {P,T<:NamedDimsWrapper{<:Any,P}} = P
+ArrayInterface.has_dimnames(::Type{T}) where {T<:NamedDimsWrapper} = true
+ArrayInterface.dimnames(::Type{T}) where {L,T<:NamedDimsWrapper{L}} = L
+Base.parent(x::NamedDimsWrapper) = x.parent
+Base.size(x::NamedDimsWrapper) = size(parent(x))
+Base.axes(x::NamedDimsWrapper) = axes(parent(x))
+
+Base.getindex(x::NamedDimsWrapper; kwargs...) = ArrayInterface.getindex(x; kwargs...)
+Base.getindex(x::NamedDimsWrapper, args...) = ArrayInterface.getindex(x, args...)
+Base.setindex!(x::NamedDimsWrapper, val; kwargs...) = ArrayInterface.setindex!(x, val; kwargs...)
+Base.setindex!(x::NamedDimsWrapper, val, args...) = ArrayInterface.setindex!(x, val, args...)
+function ArrayInterface.unsafe_get_element(x::NamedDimsWrapper, inds; kwargs...)
+    return @inbounds(parent(x)[inds...])
+end
+function ArrayInterface.unsafe_set_element!(x::NamedDimsWrapper, val, inds; kwargs...)
+    return @inbounds(parent(x)[inds...] = val)
+end
+
+val_has_dimnames(x) = Val(ArrayInterface.has_dimnames(x))
+val_dimnames(x) = Val(ArrayInterface.dimnames(x))
+val_dimnames(x, d) = Val(ArrayInterface.dimnames(x, d))
+
+d = (:x, :y)
+x = NamedDimsWrapper{d}(ones(2,2))
+dnums = ntuple(+, length(d))
+@test @inferred(val_has_dimnames(x)) === Val(true)
+@test @inferred(val_has_dimnames(typeof(x)))  === Val(true)
+@test @inferred(val_dimnames(x)) === Val(d)
+@test @inferred(val_dimnames(x')) === Val(reverse(d))
+@test @inferred(val_dimnames(PermutedDimsArray(x, (2, 1)))) ===Val(reverse(d))
+@test @inferred(val_dimnames(view(x, :, 1))) === Val((:x,))
+@test @inferred(val_dimnames(x, ArrayInterface.One())) === Val(:x)
+@test @inferred(ArrayInterface.to_dims(x, d)) === dnums
+@test @inferred(ArrayInterface.to_dims(x, reverse(d))) === reverse(dnums)
+@test_throws ArgumentError ArrayInterface.to_dims(x, :z)
+
+x[x = 1] = [2, 3]
+@test @inferred(getindex(x, x = 1)) == [2, 3]
+
+@testset "order_named_inds" begin
+    @test ArrayInterface.order_named_inds(Val((:x,)); x=2) == (2,)
+    @test ArrayInterface.order_named_inds(Val((:x, :y)); x=2) == (2, :)
+    @test ArrayInterface.order_named_inds(Val((:x, :y)); y=2, ) == (:, 2)
+    @test ArrayInterface.order_named_inds(Val((:x, :y)); y=20, x=30) == (30, 20)
+    @test ArrayInterface.order_named_inds(Val((:x, :y)); x=30, y=20) == (30, 20)
+end
+
+@testset "tuple_issubset" begin
+    @test ArrayInterface.tuple_issubset((:a, :c), (:a, :b, :c)) == true
+    @test ArrayInterface.tuple_issubset((:a, :b, :c), (:a, :c)) == false
+end
+
+end

--- a/test/dimensions.jl
+++ b/test/dimensions.jl
@@ -11,6 +11,7 @@ ArrayInterface.dimnames(::Type{T}) where {L,T<:NamedDimsWrapper{L}} = L
 Base.parent(x::NamedDimsWrapper) = x.parent
 Base.size(x::NamedDimsWrapper) = size(parent(x))
 Base.axes(x::NamedDimsWrapper) = axes(parent(x))
+Base.strides(x::NamedDimsWrapper) = Base.strides(parent(x))
 
 Base.getindex(x::NamedDimsWrapper; kwargs...) = ArrayInterface.getindex(x; kwargs...)
 Base.getindex(x::NamedDimsWrapper, args...) = ArrayInterface.getindex(x, args...)
@@ -40,6 +41,11 @@ dnums = ntuple(+, length(d))
 @test @inferred(ArrayInterface.to_dims(x, d)) === dnums
 @test @inferred(ArrayInterface.to_dims(x, reverse(d))) === reverse(dnums)
 @test_throws ArgumentError ArrayInterface.to_dims(x, :z)
+
+@test @inferred(ArrayInterface.size(x, :x)) == size(parent(x), 1)
+@test @inferred(ArrayInterface.axes(x, :x)) == axes(parent(x), 1)
+@test @inferred(ArrayInterface.strides(x, :x)) == strides(parent(x))[1]
+
 
 x[x = 1] = [2, 3]
 @test @inferred(getindex(x, x = 1)) == [2, 3]

--- a/test/dimensions.jl
+++ b/test/dimensions.jl
@@ -30,13 +30,17 @@ val_dimnames(x, d) = Val(ArrayInterface.dimnames(x, d))
 
 d = (:x, :y)
 x = NamedDimsWrapper{d}(ones(2,2))
+y = NamedDimsWrapper{(:x,)}(ones(2))
 dnums = ntuple(+, length(d))
 @test @inferred(val_has_dimnames(x)) === Val(true)
 @test @inferred(val_has_dimnames(typeof(x)))  === Val(true)
 @test @inferred(val_dimnames(x)) === Val(d)
 @test @inferred(val_dimnames(x')) === Val(reverse(d))
+@test @inferred(val_dimnames(y')) === Val((:_, :x))
 @test @inferred(val_dimnames(PermutedDimsArray(x, (2, 1)))) ===Val(reverse(d))
 @test @inferred(val_dimnames(view(x, :, 1))) === Val((:x,))
+@test @inferred(val_dimnames(view(x, :, :, :))) === Val((:x, :y, :_))
+@test @inferred(val_dimnames(view(x, :, 1, :))) === Val((:x, :_))
 @test @inferred(val_dimnames(x, ArrayInterface.One())) === Val(:x)
 @test @inferred(ArrayInterface.to_dims(x, d)) === dnums
 @test @inferred(ArrayInterface.to_dims(x, reverse(d))) === reverse(dnums)
@@ -45,7 +49,6 @@ dnums = ntuple(+, length(d))
 @test @inferred(ArrayInterface.size(x, :x)) == size(parent(x), 1)
 @test @inferred(ArrayInterface.axes(x, :x)) == axes(parent(x), 1)
 @test @inferred(ArrayInterface.strides(x, :x)) == strides(parent(x))[1]
-
 
 x[x = 1] = [2, 3]
 @test @inferred(getindex(x, x = 1)) == [2, 3]

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -514,4 +514,5 @@ end
 end
 
 include("indexing.jl")
+include("dimensions.jl")
 


### PR DESCRIPTION
Currently there is no standard meaning for keyword arguments when passed to `getindex`. Often keyword arguments are propagated optional arguments for some method along the call chain. However, the most popular use of keyword arguments for indexing (as far as I'm aware) is that implemented by NamedDims.jl where dimension names are the keywords. As discussed in [this issue](https://github.com/invenia/NamedDims.jl/issues/147), this is problematic if the wrapper around a named dimension array alters the dimensions of an array (e.g., `SubArray`) because the indices associated with the keyword arguments passed on to subsequent calls don't necessary have the same meaning once the wrapper is removed (e.g., `getindex(x; kwargs...) = getindex(parent(x); kwargs...)`) .

In this PR I added a minimal interface for incorporating named dimensions in the indexing pipeline. This provides generic support for what is arguably the most widely used application of keyword arguments for array indexing. This still propagates kwargs when the array doesn't have any dimension names. Since there currently isn't generic propagation of kwargs for indexing this shouldn't break anything.

Somewhat orthogonal to the issue of formalizing the keywords component of the indexing interface, this also standardizes named dimensions. It would be really nice if users didn't have to bother with figuring out if the model they used returns a `NamedDims.NamedDimsArray`,  `DimensionalData.AbstractDimArray`, or `AxisArrays.AxisArray` when using NamedDims.jl, DimensionalData.jl, or AxisArrays.jl when indexing.

Some of the code is from NamedDims.jl but a lot of it still needs to be benchmarked and tested. I figured I'd wait to do that until I knew if this was a desirable addition and if people agreed on the interface.

@oxinabox , you may be interested in this.