### PR TITLE
Fix contiguous_axis for PermutedDimsArray with discontiguous parent

### DIFF
--- a/src/stridelayout.jl
+++ b/src/stridelayout.jl
@@ -27,7 +27,8 @@ end
 function contiguous_axis(::Type{<:PermutedDimsArray{T,N,I1,I2,A}}) where {T,N,I1,I2,A<:AbstractArray{T,N}}
     c = contiguous_axis(A)
     isnothing(c) && return nothing
-    new_contig = I2[_get(c)]
+    contig = _get(c)
+    new_contig = contig == -1 ? -1 : I2[_get(c)]
     Contiguous{new_contig}()
 end
 function contiguous_axis(::Type{S}) where {N,NP,T,A<:AbstractArray{T,NP},I,S <: SubArray{T,N,A,I}}

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -273,6 +273,7 @@ end
     @test @inferred(contiguous_axis(transpose(@view(PermutedDimsArray(A,(3,1,2))[2,1:2,:])))) === ArrayInterface.Contiguous(2)
     @test @inferred(contiguous_axis(@view(PermutedDimsArray(A,(3,1,2))[2:3,1:2,:]))) === ArrayInterface.Contiguous(2)
     @test @inferred(contiguous_axis(@view(PermutedDimsArray(A,(3,1,2))[2:3,2,:]))) === ArrayInterface.Contiguous(-1)
+    @test @inferred(contiguous_axis(PermutedDimsArray(@view(A[2,:,:]),(2,1)))) === ArrayInterface.Contiguous(-1)
     @test @inferred(contiguous_axis(@view(PermutedDimsArray(A,(3,1,2))[2:3,2,:])')) === ArrayInterface.Contiguous(-1)
     @test @inferred(contiguous_axis(@view(PermutedDimsArray(A,(3,1,2))[:,1:2,1])')) === ArrayInterface.Contiguous(1)
 


### PR DESCRIPTION
This fixes `contiguous_axis(A)` when `A` is a `PermutedDimsArray` with a discontiguous parent array.

Example:

```julia
u = zeros(3, 4, 5)
v = @view u[2, :, :]  # discontiguous subarray
A = PermutedDimsArray(v, (2, 1))

contiguous_axis(v)  # returns Contiguous(-1) as expected
contiguous_axis(A)  # BoundsError: attempt to access (2, 1) at index [-1]
```

After the changes, `contiguous_axis(A)` returns `Contiguous(-1)`.
