### PR TITLE
Improve handling of general SubArrays

### DIFF
--- a/src/stridelayout.jl
+++ b/src/stridelayout.jl
@@ -39,18 +39,19 @@ _contiguous_axis(::Any, ::Nothing) = nothing
     n = 0
     new_contig = contig = C
     for np in 1:NP
-        if I.parameters[np] <: AbstractUnitRange
+        p = I.parameters[np]
+        if p <: OrdinalRange
             n += 1
             if np == contig
-                new_contig = n
+                new_contig = (p <: AbstractUnitRange) ? n : -1
             end
-        else
+        elseif p <: Integer
             if np == contig
                 new_contig = -1
             end
         end
     end
-    # If n != N, then an axis was indexed by something other than an integer or `AbstractUnitRange`, so we return `nothing`.
+    # If n != N, then an axis was indexed by something other than an integer or `OrdinalRange`, so we return `nothing`.
     n == N || return nothing
     Expr(:call, Expr(:curly, :Contiguous, new_contig))
 end

--- a/src/stridelayout.jl
+++ b/src/stridelayout.jl
@@ -300,7 +300,9 @@ strides(B::S) where {N,NP,T,A<:AbstractArray{T,NP},I,S <: SubArray{T,N,A,I}} = _
     for n in 1:N
         if (I.parameters[n] <: Base.Slice)
             push!(t.args, :(@inbounds(_try_static(A[$n], l[$n]))))
-        elseif I.parameters[n] <: AbstractUnitRange
+        elseif I.parameters[n] <: Number
+            nothing
+        else
             push!(t.args, Expr(:ref, :l, n))
         end
     end

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -355,6 +355,7 @@ using OffsetArrays
     M = @MArray zeros(2,3,4); Mp = @view(PermutedDimsArray(M,(3,1,2))[:,2,:])';
     Sp2 = @view(PermutedDimsArray(S,(3,2,1))[2:3,:,:]);
     Mp2 = @view(PermutedDimsArray(M,(3,1,2))[2:3,:,2])';
+    D = @view(A[:,2:2:4,:])
 
     @test @inferred(ArrayInterface.size(A)) === (3,4,5)
     @test @inferred(ArrayInterface.size(Ap)) === (2,5)
@@ -377,6 +378,7 @@ using OffsetArrays
     @test @inferred(ArrayInterface.size(M)) == size(M)
     @test @inferred(ArrayInterface.size(Mp)) == size(Mp)
     @test @inferred(ArrayInterface.size(Mp2)) == size(Mp2)
+    @test @inferred(ArrayInterface.size(D)) == size(D)
 
     @test @inferred(ArrayInterface.strides(A)) === (StaticInt(1), 3, 12)
     @test @inferred(ArrayInterface.strides(Ap)) === (StaticInt(1), 12)

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -265,6 +265,8 @@ Base.getindex(::DummyZeros{T}, inds...) where {T} = zero(T)
 
 @testset "Memory Layout" begin
     A = zeros(3,4,5);
+    D1 = view(A, 1:2:3, :, :)  # first dimension is discontiguous
+    D2 = view(A, :, 2:2:4, :)  # first dimension is contiguous
     @test device(A) === ArrayInterface.CPUPointer()
     @test device((1,2,3)) === ArrayInterface.CPUIndex()
     @test device(PermutedDimsArray(A,(3,1,2))) === ArrayInterface.CPUPointer()
@@ -277,6 +279,8 @@ Base.getindex(::DummyZeros{T}, inds...) where {T} = zero(T)
 
     @test @inferred(contiguous_axis(@SArray(zeros(2,2,2)))) === ArrayInterface.Contiguous(1)
     @test @inferred(contiguous_axis(A)) === ArrayInterface.Contiguous(1)
+    @test @inferred(contiguous_axis(D1)) === ArrayInterface.Contiguous(-1)
+    @test @inferred(contiguous_axis(D2)) === ArrayInterface.Contiguous(1)
     @test @inferred(contiguous_axis(PermutedDimsArray(A,(3,1,2)))) === ArrayInterface.Contiguous(2)
     @test @inferred(contiguous_axis(@view(PermutedDimsArray(A,(3,1,2))[2,1:2,:]))) === ArrayInterface.Contiguous(1)
     @test @inferred(contiguous_axis(transpose(@view(PermutedDimsArray(A,(3,1,2))[2,1:2,:])))) === ArrayInterface.Contiguous(2)


### PR DESCRIPTION
This PR includes two commits that are meant to improve the handling of `SubArray`s, notably those that include non-unit steps.

The first commit fixes `ArrayInterface.size` for certain `SubArray`s, and should close #85.

The second commit changes the definition of `contiguous_axis` for views with non-unit steps. For instance:

```julia
A = zeros(3,4,5);
D1 = view(A, 1:2:3, :, :)  # first dimension is discontiguous
D2 = view(A, :, 2:2:4, :)  # first dimension is contiguous

contiguous_axis(D1)  # now returns Contiguous(-1)
contiguous_axis(D2)  # now returns Contiguous(1)
```

These two examples previously returned `nothing`.
