### PR TITLE
Sub array vector subset

### DIFF
--- a/src/stridelayout.jl
+++ b/src/stridelayout.jl
@@ -45,6 +45,9 @@ _contiguous_axis(::Any, ::Nothing) = nothing
             if np == contig
                 new_contig = (p <: AbstractUnitRange) ? n : -1
             end
+        elseif p <: AbstractArray
+            n += 1
+            new_contig = np == contig ? -1 : new_contig
         elseif p <: Integer
             if np == contig
                 new_contig = -1
@@ -144,7 +147,7 @@ _stride_rank(::Any, ::Any) = nothing
     n = 0
     for np in 1:NP
         r = rankv[np]
-        if I.parameters[np] <: AbstractUnitRange
+        if I.parameters[np] <: AbstractArray
             n += 1
             push!(rank_new, r)
         end

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -323,7 +323,7 @@ Base.getindex(::DummyZeros{T}, inds...) where {T} = zero(T)
     @test @inferred(stride_rank(@view(PermutedDimsArray(A,(3,1,2))[2:3,2,:])')) === ArrayInterface.StrideRank((2, 3))
     @test @inferred(stride_rank(@view(PermutedDimsArray(A,(3,1,2))[:,1:2,1])')) === ArrayInterface.StrideRank((1, 3))
     @test @inferred(stride_rank(@view(PermutedDimsArray(A,(3,1,2))[:,2,1])')) === ArrayInterface.StrideRank((2, 1))
-    @test @inferred(stride_Rank(@view(PermutedDimsArray(A,(3,1,2))[:,1:2,[1,3,4]]))) === ArrayInterface.StrideRank((3, 1, 2))
+    @test @inferred(stride_rank(@view(PermutedDimsArray(A,(3,1,2))[:,1:2,[1,3,4]]))) === ArrayInterface.StrideRank((3, 1, 2))
 
     @test @inferred(ArrayInterface.is_column_major(@SArray(zeros(2,2,2)))) === Val{true}()
     @test @inferred(ArrayInterface.is_column_major(A)) === Val{true}()

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -300,6 +300,7 @@ Base.getindex(::DummyZeros{T}, inds...) where {T} = zero(T)
     @test @inferred(ArrayInterface.contiguous_axis_indicator(@view(PermutedDimsArray(A,(3,1,2))[2:3,2,:]))) === (Val(false),Val(false))
     @test @inferred(ArrayInterface.contiguous_axis_indicator(@view(PermutedDimsArray(A,(3,1,2))[2:3,2,:])')) === (Val(false),Val(false))
     @test @inferred(ArrayInterface.contiguous_axis_indicator(@view(PermutedDimsArray(A,(3,1,2))[:,1:2,1])')) === (Val(true),Val(false))
+    @test @inferred(ArrayInterface.contiguous_axis_indicator(@view(PermutedDimsArray(A,(3,1,2))[:,1:2,[1,3,4]]))) === (Val(false),Val(true),Val(false))
     @test @inferred(ArrayInterface.contiguous_axis_indicator(DummyZeros(3,4))) === nothing
 
     @test @inferred(contiguous_batch_size(@SArray(zeros(2,2,2)))) === ArrayInterface.ContiguousBatch(0)
@@ -322,6 +323,7 @@ Base.getindex(::DummyZeros{T}, inds...) where {T} = zero(T)
     @test @inferred(stride_rank(@view(PermutedDimsArray(A,(3,1,2))[2:3,2,:])')) === ArrayInterface.StrideRank((2, 3))
     @test @inferred(stride_rank(@view(PermutedDimsArray(A,(3,1,2))[:,1:2,1])')) === ArrayInterface.StrideRank((1, 3))
     @test @inferred(stride_rank(@view(PermutedDimsArray(A,(3,1,2))[:,2,1])')) === ArrayInterface.StrideRank((2, 1))
+    @test @inferred(stride_Rank(@view(PermutedDimsArray(A,(3,1,2))[:,1:2,[1,3,4]]))) === ArrayInterface.StrideRank((3, 1, 2))
 
     @test @inferred(ArrayInterface.is_column_major(@SArray(zeros(2,2,2)))) === Val{true}()
     @test @inferred(ArrayInterface.is_column_major(A)) === Val{true}()


### PR DESCRIPTION
@timholy, fix for [this comment](https://github.com/SciML/ArrayInterface.jl/pull/88#issuecomment-725343748).
```julia
julia> A = rand(3,4,5);

julia> D1 = view(A, :, :, [1, 3, 4]);

julia> ArrayInterface.contiguous_axis(D1)
ArrayInterface.Contiguous{1}()

julia> ArrayInterface.contiguous_axis_indicator(D1)
(Val{true}(), Val{false}(), Val{false}())

julia> ArrayInterface.stride_rank(D1)
ArrayInterface.StrideRank{(1, 2, 3)}()
```
