### PR TITLE
Prettier StaticInt print

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,6 +1,6 @@
 name = "ArrayInterface"
 uuid = "4fba245c-0d91-5ea0-9b3e-6abc04ee57a9"
-version = "2.14.7"
+version = "2.14.8"
 
 [deps]
 LinearAlgebra = "37e2e46d-f89d-539d-b4ee-838fcccc9c8e"

--- a/src/ranges.jl
+++ b/src/ranges.jl
@@ -464,3 +464,15 @@ end
     lst = _try_static(static_last(x), static_last(y))
     return Base.Slice(OptionallyStaticUnitRange(fst, lst))
 end
+
+function Base.show(io::IO, r::OptionallyStaticRange)
+    print(io, first(r))
+    if known_step(r) === 1
+        print(io, ":")
+    else
+        print(io, ":")
+        print(io, step(r))
+        print(io, ":")
+    end
+    print(io, last(r))
+end

--- a/src/static.jl
+++ b/src/static.jl
@@ -1,11 +1,15 @@
 
 """
+    StaticInt(N::Int) -> StaticInt{N}()
+
 A statically sized `Int`.
 Use `StaticInt(N)` instead of `Val(N)` when you want it to behave like a number.
 """
 struct StaticInt{N} <: Integer
     StaticInt{N}() where {N} = new{N::Int}()
 end
+
+Base.show(io::IO, ::StaticInt{N}) where {N} = print(io, "Static($N)")
 
 const Zero = StaticInt{0}
 const One = StaticInt{1}


### PR DESCRIPTION
Changes printing as discussed in #96:

```julia
julia> StaticInt(1)
Static(1)

julia> StaticInt(1):StaticInt(10)
Static(1):Static(10)

julia> StaticInt(1):StaticInt(2):StaticInt(10)
Static(1):Static(2):Static(9)
```

The nice thing about using `Static` is that it could become a standard way of informing the user that whatever is inside the brackets is a static type, instead of every new static type having it's own print out. The downside is that you can't just copy and paste things from REPL (e.g., instead printing `StaticInt(1):StaticInt(10)`. 