### PR TITLE
Clean `@pure` issues in "dimensions.jl" and "static.jl"

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,6 +1,6 @@
 name = "ArrayInterface"
 uuid = "4fba245c-0d91-5ea0-9b3e-6abc04ee57a9"
-version = "3.0.2"
+version = "3.1"
 
 [deps]
 IfElse = "615f187c-cbe4-4ef1-ba3b-2fcf58d6d173"

--- a/README.md
+++ b/README.md
@@ -167,7 +167,7 @@ Returns the rank of each stride.
 
 ## is_column_major(A)
 
-Returns a `Val{true}()` if `A` is column major, and a `Val{false}()` otherwise.`
+Returns a `Val{true}()` if `A` is column major, and a `Val{false}()` otherwise.
 
 ## dense_dims(::Type{T})
 Returns a tuple of indicators for whether each axis is dense.
@@ -207,6 +207,10 @@ For example, if `A isa Base.Matrix`, `offsets(A) === (StaticInt(1), StaticInt(1)
 ## can_avx(f)
 
 Is the function `f` whitelisted for `LoopVectorization.@avx`?
+
+## static(x)
+Returns a static form of `x`. If `x` is already in a static form then `x` is returned. If
+there is no static alternative for `x` then an error is thrown.
 
 ## StaticInt(N::Int)
 

--- a/README.md
+++ b/README.md
@@ -152,7 +152,7 @@ If unknown, it returns `nothing`.
 
 ## contiguous_axis_indicator(::Type{T})
 
-Returns a tuple of boolean `Val`s indicating whether that axis is contiguous.
+Returns a tuple of boolean `StaticBool`s indicating whether that axis is contiguous.
 
 ## contiguous_batch_size(::Type{T})
 
@@ -167,7 +167,7 @@ Returns the rank of each stride.
 
 ## is_column_major(A)
 
-Returns a `Val{true}()` if `A` is column major, and a `Val{false}()` otherwise.
+Returns a `True` if `A` is column major, and a `True/False` otherwise.
 
 ## dense_dims(::Type{T})
 Returns a tuple of indicators for whether each axis is dense.

--- a/src/ArrayInterface.jl
+++ b/src/ArrayInterface.jl
@@ -8,6 +8,14 @@ using Base.Cartesian
 
 using Base: @propagate_inbounds, tail, OneTo, LogicalIndex, Slice, ReinterpretArray
 
+@static if VERSION >= v"1.7.0-DEV.421"
+    using Base: @aggressive_constprop
+else
+    macro aggressive_constprop(ex)
+        ex
+    end
+end
+
 Base.@pure __parameterless_type(T) = Base.typename(T).wrapper
 parameterless_type(x) = parameterless_type(typeof(x))
 parameterless_type(x::Type) = __parameterless_type(x)

--- a/src/ArrayInterface.jl
+++ b/src/ArrayInterface.jl
@@ -4,8 +4,9 @@ using IfElse
 using Requires
 using LinearAlgebra
 using SparseArrays
+using Base.Cartesian
 
-using Base: @pure, @propagate_inbounds, tail, OneTo, LogicalIndex, Slice, ReinterpretArray
+using Base: @propagate_inbounds, tail, OneTo, LogicalIndex, Slice, ReinterpretArray
 
 Base.@pure __parameterless_type(T) = Base.typename(T).wrapper
 parameterless_type(x) = parameterless_type(typeof(x))

--- a/src/dimensions.jl
+++ b/src/dimensions.jl
@@ -1,5 +1,4 @@
 
-
 #julia> @btime ArrayInterface.is_increasing(ArrayInterface.nstatic(Val(10)))
 #  0.045 ns (0 allocations: 0 bytes)
 #ArrayInterface.True()
@@ -183,7 +182,12 @@ order_named_inds(x::Tuple, ::NamedTuple{(),Tuple{}}) = ()
 function order_named_inds(x::Tuple, nd::NamedTuple{L}) where {L}
     return order_named_inds(x, static(Val(L)), Tuple(nd))
 end
-function order_named_inds(x::Tuple{Vararg{Any,N}}, nd::Tuple, inds::Tuple) where {N}
+@aggressive_constprop function order_named_inds(
+    x::Tuple{Vararg{Any,N}},
+    nd::Tuple,
+    inds::Tuple
+) where {N}
+
     out = eachop(((x, nd, inds), i) -> order_named_inds(x, nd, inds, i), (x, nd, inds), nstatic(Val(N)))
     _order_named_inds_check(out, length(nd))
     return out

--- a/src/dimensions.jl
+++ b/src/dimensions.jl
@@ -111,21 +111,11 @@ end
         return dimnames(parent_type(T))
     end
 end
-@inline function dimnames(::Type{T}) where {T<:Union{Transpose,Adjoint}}
-    return _transpose_dimnames(Val(dimnames(parent_type(T))))
+@inline function dimnames(::Type{T}) where {T<:Union{Adjoint,Transpose}}
+    _transpose_dimnames(dimnames(parent_type(T)))
 end
-# inserting the Val here seems to help inferability; I got a test failure without it.
-function _transpose_dimnames(::Val{S}) where {S}
-    if length(S) == 1
-        (SUnderscore, first(S))
-    elseif length(S) == 2
-        (last(S), first(S))
-    else
-        throw("Can't transpose $S of dim $(length(S)).")
-    end
-end
-@inline _transpose_dimnames(x::Tuple{Symbol,Symbol}) = (last(x), first(x))
-@inline _transpose_dimnames(x::Tuple{Symbol}) = (SUnderscore, first(x))
+@inline _transpose_dimnames(x::Tuple{Any,Any}) = (last(x), first(x))
+@inline _transpose_dimnames(x::Tuple{Any}) = (SUnderscore, first(x))
 
 @inline function dimnames(::Type{T}) where {I,T<:PermutedDimsArray{<:Any,<:Any,I}}
     return map(i -> dimnames(parent_type(T), i), I)

--- a/src/dimensions.jl
+++ b/src/dimensions.jl
@@ -1,4 +1,5 @@
 
+
 #julia> @btime ArrayInterface.is_increasing(ArrayInterface.nstatic(Val(10)))
 #  0.045 ns (0 allocations: 0 bytes)
 #ArrayInterface.True()
@@ -39,9 +40,7 @@ from_parent_dims(::Type{<:SubArray{T,N,A,I}}) where {T,N,A,I} = _from_sub_dims(A
     end
     out
 end
-function from_parent_dims(::Type{<:PermutedDimsArray{T,N,<:Any,I}}) where {T,N,I}
-    return _val_to_static(Val(I))
-end
+from_parent_dims(::Type{<:PermutedDimsArray{T,N,<:Any,I}}) where {T,N,I} = static(Val(I))
 
 """
     to_parent_dims(::Type{T}) -> Bool
@@ -51,7 +50,7 @@ Returns the mapping from child dimensions to parent dimensions.
 to_parent_dims(x) = to_parent_dims(typeof(x))
 to_parent_dims(::Type{T}) where {T} = nstatic(Val(ndims(T)))
 to_parent_dims(::Type{T}) where {T<:Union{Transpose,Adjoint}} = (StaticInt(2), One())
-to_parent_dims(::Type{<:PermutedDimsArray{T,N,I}}) where {T,N,I} = _val_to_static(Val(I))
+to_parent_dims(::Type{<:PermutedDimsArray{T,N,I}}) where {T,N,I} = static(Val(I))
 to_parent_dims(::Type{<:SubArray{T,N,A,I}}) where {T,N,A,I} = _to_sub_dims(A, I)
 @generated function _to_sub_dims(::Type{A}, ::Type{I}) where {A,N,I<:Tuple{Vararg{Any,N}}}
     out = Expr(:tuple)
@@ -79,18 +78,35 @@ function has_dimnames(::Type{T}) where {T}
     end
 end
 
+# this takes the place of dimension names that aren't defined
+const SUnderscore = StaticSymbol(:_)
+
 """
-    dimnames(::Type{T}) -> Tuple{Vararg{Symbol}}
-    dimnames(::Type{T}, d) -> Symbol
+    dimnames(::Type{T}) -> Tuple{Vararg{StaticSymbol}}
+    dimnames(::Type{T}, dim) -> StaticSymbol
 
 Return the names of the dimensions for `x`.
 """
 @inline dimnames(x) = dimnames(typeof(x))
-@inline dimnames(x, i::Integer) = dimnames(typeof(x), i)
-@inline dimnames(::Type{T}, d::Integer) where {T} = getfield(dimnames(T), to_dims(T, d))
+@inline dimnames(x, dim::Int) = dimnames(typeof(x), dim)
+@inline dimnames(x, dim::StaticInt) = dimnames(typeof(x), dim)
+@inline function dimnames(::Type{T}, ::StaticInt{dim}) where {T,dim}
+    if ndims(T) < dim
+        return SUnderscore
+    else
+        return getfield(dimnames(T), dim)
+    end
+end
+@inline function dimnames(::Type{T}, dim::Int) where {T}
+    if ndims(T) < dim
+        return SUnderscore
+    else
+        return getfield(dimnames(T), dim)
+    end
+end
 @inline function dimnames(::Type{T}) where {T}
     if parent_type(T) <: T
-        return ntuple(i -> :_, Val(ndims(T)))
+        return ntuple(_ -> SUnderscore, Val(ndims(T)))
     else
         return dimnames(parent_type(T))
     end
@@ -101,7 +117,7 @@ end
 # inserting the Val here seems to help inferability; I got a test failure without it.
 function _transpose_dimnames(::Val{S}) where {S}
     if length(S) == 1
-        (:_, first(S))
+        (SUnderscore, first(S))
     elseif length(S) == 2
         (last(S), first(S))
     else
@@ -109,7 +125,7 @@ function _transpose_dimnames(::Val{S}) where {S}
     end
 end
 @inline _transpose_dimnames(x::Tuple{Symbol,Symbol}) = (last(x), first(x))
-@inline _transpose_dimnames(x::Tuple{Symbol}) = (:_, first(x))
+@inline _transpose_dimnames(x::Tuple{Symbol}) = (SUnderscore, first(x))
 
 @inline function dimnames(::Type{T}) where {I,T<:PermutedDimsArray{<:Any,<:Any,I}}
     return map(i -> dimnames(parent_type(T), i), I)
@@ -123,7 +139,7 @@ end
     for i in 1:length(I)
         if I[i] > 0
             if nl < i
-                push!(e.args, QuoteNode(:_))
+                push!(e.args, :(ArrayInterface.SUnderscore))
             else
                 push!(e.args, QuoteNode(L[i]))
             end
@@ -132,83 +148,74 @@ end
     return e
 end
 
+_to_int(x::Integer) = Int(x)
+_to_int(x::StaticInt) = x
+
+function no_dimname_error(@nospecialize(x), @nospecialize(dim))
+    throw(ArgumentError("($(repr(dim))) does not correspond to any dimension of ($(x))"))
+end
+
 """
-    to_dims(x[, d])
+    to_dims(::Type{T}, dim) -> Integer
 
 This returns the dimension(s) of `x` corresponding to `d`.
 """
-to_dims(x, d) = to_dims(dimnames(x), d)
-to_dims(x::Tuple{Vararg{Symbol}}, d::Integer) = Int(d)
-to_dims(x::Tuple{Vararg{Symbol}}, d::Colon) = d   # `:` is the default for most methods that take `dims`
-@inline to_dims(x::Tuple{Vararg{Symbol}}, d::Tuple) = map(i -> to_dims(x, i), d)
-@inline function to_dims(x::Tuple{Vararg{Symbol}}, d::Symbol)::Int
-    i = _sym_to_dim(x, d)
-    if i === 0
-        throw(ArgumentError("Specified name ($(repr(d))) does not match any dimension name ($(x))"))
-    end
+to_dims(x, dim) = to_dims(typeof(x), dim)
+to_dims(::Type{T}, dim::Integer) where {T} = _to_int(dim)
+to_dims(::Type{T}, dim::Colon) where {T} = dim
+function to_dims(::Type{T}, dim::StaticSymbol) where {T}
+    i = find_first_eq(dim, dimnames(T))
+    i === nothing && no_dimname_error(T, dim)
     return i
 end
-Base.@pure function _sym_to_dim(x::Tuple{Vararg{Symbol,N}}, sym::Symbol) where {N}
-    for i in 1:N
-        getfield(x, i) === sym && return i
-    end
-    return 0
+@inline function to_dims(::Type{T}, dim::Symbol) where {T}
+    i = find_first_eq(dim, Symbol.(dimnames(T)))
+    i === nothing && no_dimname_error(T, dim)
+    return i
 end
+to_dims(::Type{T}, dims::Tuple) where {T} = map(i -> to_dims(T, i), dims)
 
-"""
-    tuple_issubset
-
-A version of `issubset` sepecifically for `Tuple`s of `Symbol`s, that is `@pure`.
-This helps it get optimised out of existance. It is less of an abuse of `@pure` than
-most of the stuff for making `NamedTuples` work.
-"""
-Base.@pure function tuple_issubset(
-    lhs::Tuple{Vararg{Symbol,N}}, rhs::Tuple{Vararg{Symbol,M}}
-) where {N,M}
-    N <= M || return false
-    for a in lhs
-        found = false
-        for b in rhs
-            found |= a === b
-        end
-        found || return false
-    end
-    return true
-end
-
-"""
-    order_named_inds(Val(names); kwargs...)
-    order_named_inds(Val(names), namedtuple)
+#=
+    order_named_inds(names, namedtuple)
+    order_named_inds(names, subnames, inds)
 
 Returns the tuple of index values for an array with `names`, when indexed by keywords.
 Any dimensions not fixed are given as `:`, to make a slice.
 An error is thrown if any keywords are used which do not occur in `nda`'s names.
-"""
-@inline function order_named_inds(val::Val{L}; kwargs...) where {L}
-    if isempty(kwargs)
-        return ()
+
+
+1. parse into static dimnension names and key words.
+2. find each dimnames in key words
+3. if nothing is found use Colon()
+4. if (ndims - ncolon) === nkwargs then all were found, else error
+=#
+order_named_inds(x::Tuple, ::NamedTuple{(),Tuple{}}) = ()
+function order_named_inds(x::Tuple, nd::NamedTuple{L}) where {L}
+    return order_named_inds(x, static(Val(L)), Tuple(nd))
+end
+function order_named_inds(x::Tuple{Vararg{Any,N}}, nd::Tuple, inds::Tuple) where {N}
+    out = eachop(((x, nd, inds), i) -> order_named_inds(x, nd, inds, i), (x, nd, inds), nstatic(Val(N)))
+    _order_named_inds_check(out, length(nd))
+    return out
+end
+function order_named_inds(x::Tuple, nd::Tuple, inds::Tuple, ::StaticInt{dim}) where {dim}
+    index = find_first_eq(getfield(x, dim), nd)
+    if index === nothing
+        return Colon()
     else
-        return order_named_inds(val, kwargs.data)
+        return @inbounds(inds[index])
     end
 end
-@generated function order_named_inds(val::Val{L}, ni::NamedTuple{K}) where {L,K}
-    tuple_issubset(K, L) || throw(DimensionMismatch("Expected subset of $L, got $K"))
-    exs = map(L) do n
-        if Base.sym_in(n, K)
-            qn = QuoteNode(n)
-            :(getfield(ni, $qn))
-        else
-            :(Colon())
-        end
+
+ncolon(x::Tuple{Colon,Vararg}, n::Int) = ncolon(tail(x), n + 1)
+ncolon(x::Tuple{Any,Vararg}, n::Int) = ncolon(tail(x), n)
+ncolon(x::Tuple{Colon}, n::Int) = n + 1
+ncolon(x::Tuple{Any}, n::Int) = n
+function _order_named_inds_check(inds::Tuple{Vararg{Any,N}}, nkwargs::Int) where {N}
+    if (N - ncolon(inds, 0)) !== nkwargs
+        error("Not all keywords matched dimension names.")
     end
-    return Expr(:tuple, exs...)
-end
-@generated function _perm_tuple(::Type{T}, ::Val{P}) where {T,P}
-    out = Expr(:curly, :Tuple)
-    for p in P
-        push!(out.args, T.parameters[p])
-    end
-    Expr(:block, Expr(:meta, :inline), out)
+    return nothing
 end
 
 """
@@ -226,14 +233,11 @@ function axes_types(::Type{T}) where {T}
         return axes_types(parent_type(T))
     end
 end
-function axes_types(::Type{T}) where {T<:Adjoint}
-    return _perm_tuple(axes_types(parent_type(T)), Val((2, 1)))
+function axes_types(::Type{T}) where {T<:MatAdjTrans}
+    return eachop_tuple(_get_tuple, axes_types(parent_type(T)), to_parent_dims(T))
 end
-function axes_types(::Type{T}) where {T<:Transpose}
-    return _perm_tuple(axes_types(parent_type(T)), Val((2, 1)))
-end
-function axes_types(::Type{T}) where {I1,T<:PermutedDimsArray{<:Any,<:Any,I1}}
-    return _perm_tuple(axes_types(parent_type(T)), Val(I1))
+function axes_types(::Type{T}) where {T<:PermutedDimsArray}
+    return eachop_tuple(_get_tuple, axes_types(parent_type(T)), to_parent_dims(T))
 end
 function axes_types(::Type{T}) where {T<:AbstractRange}
     if known_length(T) === nothing
@@ -311,8 +315,6 @@ end
     Expr(:block, Expr(:meta, :inline), out)
 end
 
-
-
 """
   size(A)
 
@@ -330,12 +332,7 @@ julia> ArrayInterface.size(A)
 @inline size(A) = Base.size(A)
 @inline size(A, d::Integer) = size(A)[Int(d)]
 @inline size(A, d) = Base.size(A, to_dims(A, d))
-@inline function size(x::LinearAlgebra.Adjoint{T,V}) where {T,V<:AbstractVector{T}}
-    return (One(), static_length(x))
-end
-@inline function size(x::LinearAlgebra.Transpose{T,V}) where {T,V<:AbstractVector{T}}
-    return (One(), static_length(x))
-end
+@inline size(x::VecAdjTrans) = (One(), static_length(x))
 
 function size(B::S) where {N,NP,T,A<:AbstractArray{T,NP},I,S<:SubArray{T,N,A,I}}
     return _size(size(parent(B)), B.indices, map(static_length, B.indices))
@@ -357,9 +354,9 @@ end
     Expr(:block, Expr(:meta, :inline), t)
 end
 @inline size(v::AbstractVector) = (static_length(v),)
-@inline size(B::MatAdjTrans) = permute(size(parent(B)), Val{(2, 1)}())
+@inline size(B::MatAdjTrans) = permute(size(parent(B)), to_parent_dims(B))
 @inline function size(B::PermutedDimsArray{T,N,I1,I2,A}) where {T,N,I1,I2,A}
-    return permute(size(parent(B)), Val{I1}())
+    return permute(size(parent(B)), to_parent_dims(B))
 end
 @inline size(A::AbstractArray, ::StaticInt{N}) where {N} = size(A)[N]
 @inline size(A::AbstractArray, ::Val{N}) where {N} = size(A)[N]

--- a/src/indexing.jl
+++ b/src/indexing.jl
@@ -432,7 +432,7 @@ Changing indexing based on a given argument from `args` should be done through
 @propagate_inbounds getindex(A, args...) = unsafe_getindex(A, to_indices(A, args))
 @propagate_inbounds function getindex(A; kwargs...)
     if has_dimnames(A)
-        return A[order_named_inds(Val(dimnames(A)); kwargs...)...]
+        return A[order_named_inds(dimnames(A), kwargs.data)...]
     else
         return unsafe_getindex(A, to_indices(A, ()); kwargs...)
     end
@@ -548,7 +548,7 @@ Store the given values at the given key or index within a collection.
 end
 @propagate_inbounds function setindex!(A, val; kwargs...)
     if has_dimnames(A)
-        A[order_named_inds(Val(dimnames(A)); kwargs...)...] = val
+        A[order_named_inds(dimnames(A), kwargs.data)...] = val
     else
         return unsafe_setindex!(A, val, to_indices(A, ()); kwargs...)
     end
@@ -662,3 +662,4 @@ end
 ) where {N}
     return _generate_unsafe_setindex!_body(N)
 end
+

--- a/src/ranges.jl
+++ b/src/ranges.jl
@@ -607,3 +607,4 @@ function Base.show(io::IO, r::OptionallyStaticRange)
     end
     print(io, last(r))
 end
+

--- a/src/static.jl
+++ b/src/static.jl
@@ -14,7 +14,7 @@ const One = StaticInt{1}
 
 Base.show(io::IO, ::StaticInt{N}) where {N} = print(io, "static($N)")
 
-Base.@pure StaticInt(N::Int) = StaticInt{N}()
+StaticInt(N::Int) = StaticInt{N}()
 StaticInt(N::Integer) = StaticInt(convert(Int, N))
 StaticInt(::StaticInt{N}) where {N} = StaticInt{N}()
 StaticInt(::Val{N}) where {N} = StaticInt{N}()
@@ -250,7 +250,7 @@ Base.promote_rule(::Type{<:StaticBool}, ::Type{<:StaticBool}) = StaticBool
 Base.promote_rule(::Type{<:StaticBool}, ::Type{Bool}) = Bool
 Base.promote_rule(::Type{Bool}, ::Type{<:StaticBool}) = Bool
 
-Base.@pure _get_tuple(::Type{T}, ::StaticInt{i}) where {T<:Tuple, i} = T.parameters[i]
+@generated _get_tuple(::Type{T}, ::StaticInt{i}) where {T<:Tuple, i} = T.parameters[i]
 
 Base.all(::Tuple{Vararg{True}}) = true
 Base.all(::Tuple{Vararg{Union{True,False}}}) = false
@@ -260,25 +260,27 @@ Base.any(::Tuple{Vararg{True}}) = true
 Base.any(::Tuple{Vararg{Union{True,False}}}) = true
 Base.any(::Tuple{Vararg{False}}) = false
 
-Base.@pure nstatic(::Val{N}) where {N} = ntuple(i -> StaticInt(i), Val(N))
+@inline nstatic(::Val{N}) where {N} = ntuple(i -> StaticInt(i), Val(N))
 
-# I is a tuple of Int
-@pure function _val_to_static(::Val{I}) where {I}
-    return ntuple(i -> StaticInt(getfield(I, i)), Val(length(I)))
+invariant_permutation(::Any, ::Any) = False()
+function invariant_permutation(x::T, y::T) where {N,T<:Tuple{Vararg{StaticInt,N}}}
+    if x === nstatic(Val(N))
+        return True()
+    else
+        return False()
+    end
 end
 
-@pure is_permuting(perm::Tuple{Vararg{StaticInt,N}}) where {N} = perm !== nstatic(Val(N))
-
-permute(x::Tuple, perm::Tuple) = eachop(getindex, x, perm)
-function permute(x::Tuple{Vararg{Any,N}}, perm::Tuple{Vararg{Any,N}}) where {N}
-    if is_permuting(perm)
+permute(x::Tuple, perm::Val) = permute(x, static(perm))
+function permute(x::Tuple{Vararg{Any}}, perm::Tuple{Vararg{StaticInt}})
+    if invariant_permutation(perm, perm) isa False
         return eachop(getindex, x, perm)
     else
         return x
     end
 end
-permute(x::Tuple, perm::Val) = permute(x, _val_to_static(perm))
 
+@inline eachop(op, x::Tuple{Vararg{Any,N}}) where {N} = eachop(op, x, nstatic(Val(N)))
 @generated function eachop(op, x, y, ::I) where {I}
     t = Expr(:tuple)
     for p in I.parameters
@@ -288,6 +290,14 @@ permute(x::Tuple, perm::Val) = permute(x, _val_to_static(perm))
 end
 @generated function eachop(op, x, ::I) where {I}
     t = Expr(:tuple)
+    for p in I.parameters
+        push!(t.args, :(op(x, StaticInt{$(p.parameters[1])}())))
+    end
+    Expr(:block, Expr(:meta, :inline), t)
+end
+
+@generated function eachop_tuple(op, x, ::I) where {I}
+    t = Expr(:curly, :Tuple)
     for p in I.parameters
         push!(t.args, :(op(x, StaticInt{$(p.parameters[1])}())))
     end
@@ -367,10 +377,81 @@ IfElse.ifelse(::True, x, y) = x
 IfElse.ifelse(::False, x, y) = y
 
 """
+    StaticSymbol
+
+A statically typed `Symbol`.
+"""
+struct StaticSymbol{s}
+    StaticSymbol{s}() where {s} = new{s::Symbol}()
+    StaticSymbol(s::Symbol) = new{s}()
+end
+
+Base.Symbol(::StaticSymbol{s}) where {s} = s::Symbol
+
+Base.show(io::IO, ::StaticSymbol{s}) where {s} = print(io, "static(:$s)")
+
+is_static(x) = is_static(typeof(x))
+is_static(::Type{T}) where {T<:StaticInt} = True()
+is_static(::Type{T}) where {T<:StaticBool} = True()
+is_static(::Type{T}) where {T<:StaticSymbol} = True()
+is_static(::Type{T}) where {T} = False()
+
+_tuple_static(::Type{T}, i) where {T} = is_static(_get_tuple(T, i))
+function is_static(::Type{T}) where {N,T<:Tuple{Vararg{Any,N}}}
+    return all(eachop(_tuple_static, T, nstatic(Val(N))))
+end
+
+"""
     static(x)
 
-Returns a static form of `x`.
+Returns a static form of `x`. If `x` is already in a static form then `x` is returned. If
+there is no static alternative for `x` then an error is thrown.
+
+```julia
+julia> using ArrayInterface: static
+
+julia> static(1)
+static(1)
+
+julia> static(true)
+ArrayInterface.True()
+
+julia> static(:x)
+static(:x)
+
+```
 """
+function static(x)
+    if is_static(x) isa True
+        return x
+    else
+        _no_static_type(x)
+    end
+end
 static(x::Int) = StaticInt(x)
 static(x::Bool) = StaticBool(x)
+static(x::Symbol) = StaticSymbol(x)
+static(x::Tuple{Vararg{Any}}) = map(static, x)
+@generated static(::Val{V}) where {V} = :($(static(V)))
+function _no_static_type(@nospecialize(x))
+    error("There is no static alternative for type $(typeof(x)).")
+end
+
+#=
+    find_first_eq(x, collection::Tuple)
+
+Finds the position in the tuple `collection` that is exactly equal (i.e. `===`) to `x`.
+If `x` and `collection` are static (`is_static`) and `x` is in `collection` then the return
+value is a `StaticInt`.
+=#
+@generated function find_first_eq(x::X, itr::I) where {X,N,I<:Tuple{Vararg{Any,N}}}
+    if (is_static(X) & is_static(I)) isa True
+        return Expr(:block, Expr(:meta, :inline),
+            :(@nif $(N + 1) d->(x === getfield(itr, d)) d->(static(d)) d->(nothing)))
+    else
+        return Expr(:block, Expr(:meta, :inline),
+            :(@nif $(N + 1) d->(x === getfield(itr, d)) d->(d) d->(nothing)))
+    end
+end
+
 

--- a/src/stridelayout.jl
+++ b/src/stridelayout.jl
@@ -87,7 +87,7 @@ function contiguous_axis(::Type{R}) where {T,N,S,A<:Array{S},R<:ReinterpretArray
 end
 
 """
-    contiguous_axis_indicator(::Type{T}) -> Tuple{Vararg{Val}}
+    contiguous_axis_indicator(::Type{T}) -> Tuple{Vararg{StaticBool}}
 
 Returns a tuple boolean `Val`s indicating whether that axis is contiguous.
 """
@@ -96,8 +96,8 @@ function contiguous_axis_indicator(::Type{A}) where {D,A<:AbstractArray{<:Any,D}
 end
 contiguous_axis_indicator(::A) where {A<:AbstractArray} = contiguous_axis_indicator(A)
 contiguous_axis_indicator(::Nothing, ::Val) = nothing
-Base.@pure function contiguous_axis_indicator(::StaticInt{N}, ::Val{D}) where {N,D}
-    return ntuple(d -> StaticBool(d === N), Val{D}())
+function contiguous_axis_indicator(c::StaticInt{N}, dim::Val{D}) where {N,D}
+    return map(i -> eq(c, i), nstatic(dim))
 end
 
 function rank_to_sortperm(R::Tuple{Vararg{StaticInt,N}}) where {N}
@@ -106,7 +106,7 @@ function rank_to_sortperm(R::Tuple{Vararg{StaticInt,N}}) where {N}
     @inbounds for n = 1:N
         sp = Base.setindex(sp, n, r[n])
     end
-    sp
+    return sp
 end
 
 stride_rank(x) = stride_rank(typeof(x))
@@ -117,7 +117,9 @@ stride_rank(::Type{<:Tuple}) = (One(),)
 stride_rank(::Type{T}) where {T<:VecAdjTrans} = (StaticInt(2), StaticInt(1))
 stride_rank(::Type{T}) where {T<:MatAdjTrans} = _stride_rank(T, stride_rank(parent_type(T)))
 _stride_rank(::Type{T}, ::Nothing) where {T<:MatAdjTrans} = nothing
-_stride_rank(::Type{T}, rank) where {T<:MatAdjTrans} = (last(rank), first(rank))
+function _stride_rank(::Type{T}, rank) where {T<:MatAdjTrans}
+    return (getfield(rank, 2), getfield(rank, 1))
+end
 
 function stride_rank(::Type{T},) where {T<:PermutedDimsArray}
     return _stride_rank(T, stride_rank(parent_type(T)))
@@ -227,12 +229,12 @@ function dense_dims(::Type{T}) where {T<:MatAdjTrans}
         return (last(dense), first(dense))
     end
 end
-function dense_dims(::Type{<:PermutedDimsArray{T,N,I1,I2,A}}) where {T,N,I1,I2,A}
-    dense = dense_dims(A)
+function dense_dims(::Type{T}) where {T<:PermutedDimsArray}
+    dense = dense_dims(parent_type(T))
     if dense === nothing
         return nothing
     else
-        return permute(dense, Val(I1))
+        return permute(dense, to_parent_dims(T))
     end
 end
 function dense_dims(::Type{S}) where {N,NP,T,A<:AbstractArray{T,NP},I,S<:SubArray{T,N,A,I}}
@@ -361,17 +363,10 @@ compile time are represented by `nothing`.
 known_strides(x) = known_strides(typeof(x))
 known_strides(x, d) = known_strides(x)[to_dims(x, d)]
 known_strides(::Type{T}) where {T<:Vector} = (1,)
-@inline function known_strides(::Type{T}) where {T<:Adjoint{<:Any,<:AbstractVector}}
-    strd = first(known_strides(parent_type(T)))
-    return (strd, strd)
+function known_strides(::Type{T}) where {T<:MatAdjTrans}
+    return permute(known_strides(parent_type(T)), to_parent_dims(T))
 end
-function known_strides(::Type{T}) where {T<:Adjoint}
-    return permute(known_strides(parent_type(T)), Val{(2, 1)}())
-end
-function known_strides(::Type{T}) where {T<:Transpose}
-    return permute(known_strides(parent_type(T)), Val{(2, 1)}())
-end
-@inline function known_strides(::Type{T}) where {T<:Transpose{<:Any,<:AbstractVector}}
+@inline function known_strides(::Type{T}) where {T<:VecAdjTrans}
     strd = first(known_strides(parent_type(T)))
     return (strd, strd)
 end
@@ -450,9 +445,9 @@ if VERSION ≥ v"1.6.0-DEV.1581"
     end
 end
 
-@inline strides(B::MatAdjTrans) = permute(strides(parent(B)), Val{(2, 1)}())
-@inline function strides(B::PermutedDimsArray{T,N,I1,I2}) where {T,N,I1,I2}
-    return permute(strides(parent(B)), Val{I1}())
+@inline strides(B::MatAdjTrans) = permute(strides(parent(B)), to_parent_dims(B))
+@inline function strides(B::PermutedDimsArray)
+    return permute(strides(parent(B)), to_parent_dims(B))
 end
 @inline stride(A::AbstractArray, ::StaticInt{N}) where {N} = strides(A)[N]
 @inline stride(A::AbstractArray, ::Val{N}) where {N} = strides(A)[N]
@@ -479,4 +474,3 @@ stride(A, i) = Base.stride(A, i) # for type stability
     end
     Expr(:block, Expr(:meta, :inline), t)
 end
-

--- a/src/stridelayout.jl
+++ b/src/stridelayout.jl
@@ -474,3 +474,4 @@ stride(A, i) = Base.stride(A, i) # for type stability
     end
     Expr(:block, Expr(:meta, :inline), t)
 end
+

--- a/test/dimensions.jl
+++ b/test/dimensions.jl
@@ -1,3 +1,5 @@
+using ArrayInterface: dimnames
+
 @testset "dimensions" begin
 
 @testset "dimension permutations" begin
@@ -23,19 +25,16 @@
     @test @inferred(ArrayInterface.from_parent_dims(typeof(vadj))) == (2, 1)
 end
 
-@testset "to_dims" begin
-    @testset "small case" begin
-        @test ArrayInterface.to_dims((:x, :y), :x) == 1
-        @test ArrayInterface.to_dims((:x, :y), :y) == 2
-        @test_throws ArgumentError ArrayInterface.to_dims((:x, :y), :z)  # not found
-    end
-
-    @testset "large case" begin
-        @test ArrayInterface.to_dims((:x, :y, :a, :b, :c, :d), :x) == 1
-        @test ArrayInterface.to_dims((:x, :y, :a, :b, :c, :d), :a) == 3
-        @test ArrayInterface.to_dims((:x, :y, :a, :b, :c, :d), :d) == 6
-        @test_throws ArgumentError ArrayInterface.to_dims((:x, :y, :a, :b, :c, :d), :z) # not found
-    end
+@testset "order_named_inds" begin
+    n1 = (static(:x),)
+    n2 = (n1..., static(:y))
+    n3 = (n2..., static(:z))
+    @test @inferred(ArrayInterface.order_named_inds(n1, (x=2,))) == (2,)
+    @test @inferred(ArrayInterface.order_named_inds(n2, (x=2,))) == (2, :)
+    @test @inferred(ArrayInterface.order_named_inds(n2, (y=2,))) == (:, 2)
+    @test @inferred(ArrayInterface.order_named_inds(n2, (y=20, x=30))) == (30, 20)
+    @test @inferred(ArrayInterface.order_named_inds(n2, (x=30, y=20))) == (30, 20)
+    @test @inferred(ArrayInterface.order_named_inds(n3, (x=30, y=20))) == (30, 20, :)
 end
 
 struct NamedDimsWrapper{L,T,N,P<:AbstractArray{T,N}} <: AbstractArray{T,N}
@@ -44,7 +43,7 @@ struct NamedDimsWrapper{L,T,N,P<:AbstractArray{T,N}} <: AbstractArray{T,N}
 end
 ArrayInterface.parent_type(::Type{T}) where {P,T<:NamedDimsWrapper{<:Any,<:Any,<:Any,P}} = P
 ArrayInterface.has_dimnames(::Type{T}) where {T<:NamedDimsWrapper} = true
-ArrayInterface.dimnames(::Type{T}) where {L,T<:NamedDimsWrapper{L}} = L
+ArrayInterface.dimnames(::Type{T}) where {L,T<:NamedDimsWrapper{L}} = static(Val(L))
 Base.parent(x::NamedDimsWrapper) = x.parent
 Base.size(x::NamedDimsWrapper) = size(parent(x))
 Base.size(x::NamedDimsWrapper, d) = ArrayInterface.size(x, d)
@@ -65,26 +64,43 @@ function ArrayInterface.unsafe_set_element!(x::NamedDimsWrapper, val, inds; kwar
 end
 
 val_has_dimnames(x) = Val(ArrayInterface.has_dimnames(x))
-val_dimnames(x) = Val(ArrayInterface.dimnames(x))
-val_dimnames(x, d) = Val(ArrayInterface.dimnames(x, d))
 
-d = (:x, :y)
-x = NamedDimsWrapper{d}(ones(2,2))
-y = NamedDimsWrapper{(:x,)}(ones(2))
+d = (static(:x), static(:y))
+x = NamedDimsWrapper{d}(ones(2,2));
+y = NamedDimsWrapper{(:x,)}(ones(2));
 dnums = ntuple(+, length(d))
 @test @inferred(val_has_dimnames(x)) === Val(true)
 @test @inferred(val_has_dimnames(typeof(x)))  === Val(true)
-@test @inferred(val_dimnames(x)) === Val(d)
-@test @inferred(val_dimnames(x')) === Val(reverse(d))
-@test @inferred(val_dimnames(y')) === Val((:_, :x))
-@test @inferred(val_dimnames(PermutedDimsArray(x, (2, 1)))) ===Val(reverse(d))
-@test @inferred(val_dimnames(view(x, :, 1))) === Val((:x,))
-@test @inferred(val_dimnames(view(x, :, :, :))) === Val((:x, :y, :_))
-@test @inferred(val_dimnames(view(x, :, 1, :))) === Val((:x, :_))
-@test @inferred(val_dimnames(x, ArrayInterface.One())) === Val(:x)
-@test @inferred(ArrayInterface.to_dims(x, d)) === dnums
-@test @inferred(ArrayInterface.to_dims(x, reverse(d))) === reverse(dnums)
+@test @inferred(dimnames(x)) === d
+@test @inferred(dimnames(x')) === reverse(d)
+@test @inferred(dimnames(y')) === (static(:_), static(:x))
+@test @inferred(dimnames(PermutedDimsArray(x, (2, 1)))) === reverse(d)
+@test @inferred(dimnames(view(x, :, 1))) === (static(:x),)
+@test @inferred(dimnames(view(x, :, :, :))) === (static(:x),static(:y), static(:_))
+@test @inferred(dimnames(view(x, :, 1, :))) === (static(:x), static(:_))
+@test @inferred(dimnames(x, ArrayInterface.One())) === static(:x)
+@test @inferred(ArrayInterface.to_dims(x, d)) == dnums
+@test @inferred(ArrayInterface.to_dims(x, reverse(d))) == reverse(dnums)
 @test_throws ArgumentError ArrayInterface.to_dims(x, :z)
+
+
+@testset "to_dims" begin
+    x = NamedDimsWrapper{(:x, :y)}(ones(2,2));
+    y = NamedDimsWrapper{(:x, :y, :a, :b, :c, :d)}(ones(6));
+    @testset "small case" begin
+        @test @inferred(ArrayInterface.to_dims(x, :x)) == 1
+        @test @inferred(ArrayInterface.to_dims(x, :y)) == 2
+        @test_throws ArgumentError ArrayInterface.to_dims(x, :z)  # not found
+    end
+
+    @testset "large case" begin
+        @test @inferred(ArrayInterface.to_dims(y, :x)) == 1
+        @test @inferred(ArrayInterface.to_dims(y, :a)) == 3
+        @test @inferred(ArrayInterface.to_dims(y, :d)) == 6
+        @test_throws ArgumentError ArrayInterface.to_dims(y, :z) # not found
+    end
+end
+
 
 @test @inferred(size(x, :x)) == size(parent(x), 1)
 @test @inferred(axes(x, :x)) == axes(parent(x), 1)
@@ -93,17 +109,5 @@ dnums = ntuple(+, length(d))
 x[x = 1] = [2, 3]
 @test @inferred(getindex(x, x = 1)) == [2, 3]
 
-@testset "order_named_inds" begin
-    @test ArrayInterface.order_named_inds(Val((:x,)); x=2) == (2,)
-    @test ArrayInterface.order_named_inds(Val((:x, :y)); x=2) == (2, :)
-    @test ArrayInterface.order_named_inds(Val((:x, :y)); y=2, ) == (:, 2)
-    @test ArrayInterface.order_named_inds(Val((:x, :y)); y=20, x=30) == (30, 20)
-    @test ArrayInterface.order_named_inds(Val((:x, :y)); x=30, y=20) == (30, 20)
 end
 
-@testset "tuple_issubset" begin
-    @test ArrayInterface.tuple_issubset((:a, :c), (:a, :b, :c)) == true
-    @test ArrayInterface.tuple_issubset((:a, :b, :c), (:a, :c)) == false
-end
-
-end

--- a/test/dimensions.jl
+++ b/test/dimensions.jl
@@ -2,40 +2,9 @@ using ArrayInterface: dimnames
 
 @testset "dimensions" begin
 
-@testset "dimension permutations" begin
-    a = ones(2, 2, 2)
-    perm = PermutedDimsArray(a, (3, 1, 2))
-    mview = view(perm, :, 1, :)
-    madj = mview'
-    vview = view(madj, 1, :)
-    vadj = vview'
-
-    @test @inferred(ArrayInterface.to_parent_dims(typeof(a))) == (1, 2, 3)
-    @test @inferred(ArrayInterface.to_parent_dims(typeof(perm))) == (3, 1, 2)
-    @test @inferred(ArrayInterface.to_parent_dims(typeof(mview))) == (1, 3)
-    @test @inferred(ArrayInterface.to_parent_dims(typeof(madj))) == (2, 1)
-    @test @inferred(ArrayInterface.to_parent_dims(typeof(vview))) == (2,)
-    @test @inferred(ArrayInterface.to_parent_dims(typeof(vadj))) == (2, 1)
-
-    @test @inferred(ArrayInterface.from_parent_dims(typeof(a))) == (1, 2, 3)
-    @test @inferred(ArrayInterface.from_parent_dims(typeof(perm))) == (2, 3, 1)
-    @test @inferred(ArrayInterface.from_parent_dims(typeof(mview))) == (1, 0, 2)
-    @test @inferred(ArrayInterface.from_parent_dims(typeof(madj))) == (2, 1)
-    @test @inferred(ArrayInterface.from_parent_dims(typeof(vview))) == (0, 1)
-    @test @inferred(ArrayInterface.from_parent_dims(typeof(vadj))) == (2, 1)
-end
-
-@testset "order_named_inds" begin
-    n1 = (static(:x),)
-    n2 = (n1..., static(:y))
-    n3 = (n2..., static(:z))
-    @test @inferred(ArrayInterface.order_named_inds(n1, (x=2,))) == (2,)
-    @test @inferred(ArrayInterface.order_named_inds(n2, (x=2,))) == (2, :)
-    @test @inferred(ArrayInterface.order_named_inds(n2, (y=2,))) == (:, 2)
-    @test @inferred(ArrayInterface.order_named_inds(n2, (y=20, x=30))) == (30, 20)
-    @test @inferred(ArrayInterface.order_named_inds(n2, (x=30, y=20))) == (30, 20)
-    @test @inferred(ArrayInterface.order_named_inds(n3, (x=30, y=20))) == (30, 20, :)
-end
+###
+### define wrapper with dimnames
+###
 
 struct NamedDimsWrapper{L,T,N,P<:AbstractArray{T,N}} <: AbstractArray{T,N}
     parent::P
@@ -63,31 +32,73 @@ function ArrayInterface.unsafe_set_element!(x::NamedDimsWrapper, val, inds; kwar
     return @inbounds(parent(x)[inds...] = val)
 end
 
+@testset "dimension permutations" begin
+    a = ones(2, 2, 2)
+    perm = PermutedDimsArray(a, (3, 1, 2))
+    mview = view(perm, :, 1, :)
+    madj = mview'
+    vview = view(madj, 1, :)
+    vadj = vview'
+
+    @test @inferred(ArrayInterface.to_parent_dims(typeof(a))) == (1, 2, 3)
+    @test @inferred(ArrayInterface.to_parent_dims(typeof(perm))) == (3, 1, 2)
+    @test @inferred(ArrayInterface.to_parent_dims(typeof(mview))) == (1, 3)
+    @test @inferred(ArrayInterface.to_parent_dims(typeof(madj))) == (2, 1)
+    @test @inferred(ArrayInterface.to_parent_dims(typeof(vview))) == (2,)
+    @test @inferred(ArrayInterface.to_parent_dims(typeof(vadj))) == (2, 1)
+
+    @test @inferred(ArrayInterface.from_parent_dims(typeof(a))) == (1, 2, 3)
+    @test @inferred(ArrayInterface.from_parent_dims(typeof(perm))) == (2, 3, 1)
+    @test @inferred(ArrayInterface.from_parent_dims(typeof(mview))) == (1, 0, 2)
+    @test @inferred(ArrayInterface.from_parent_dims(typeof(madj))) == (2, 1)
+    @test @inferred(ArrayInterface.from_parent_dims(typeof(vview))) == (0, 1)
+    @test @inferred(ArrayInterface.from_parent_dims(typeof(vadj))) == (2, 1)
+end
+
+@testset "order_named_inds" begin
+    n1 = (static(:x),)
+    n2 = (n1..., static(:y))
+    n3 = (n2..., static(:z))
+    @test @inferred(ArrayInterface.order_named_inds(n1, NamedTuple{(),Tuple{}}(()) )) == ()
+    @test @inferred(ArrayInterface.order_named_inds(n1, (x=2,))) == (2,)
+    @test @inferred(ArrayInterface.order_named_inds(n2, (x=2,))) == (2, :)
+    @test @inferred(ArrayInterface.order_named_inds(n2, (y=2,))) == (:, 2)
+    @test @inferred(ArrayInterface.order_named_inds(n2, (y=20, x=30))) == (30, 20)
+    @test @inferred(ArrayInterface.order_named_inds(n2, (x=30, y=20))) == (30, 20)
+    @test @inferred(ArrayInterface.order_named_inds(n3, (x=30, y=20))) == (30, 20, :)
+
+    @test_throws ErrorException ArrayInterface.order_named_inds(n2, (x=30, y=20, z=40))
+end
+
 val_has_dimnames(x) = Val(ArrayInterface.has_dimnames(x))
 
-d = (static(:x), static(:y))
-x = NamedDimsWrapper{d}(ones(2,2));
-y = NamedDimsWrapper{(:x,)}(ones(2));
-dnums = ntuple(+, length(d))
-@test @inferred(val_has_dimnames(x)) === Val(true)
-@test @inferred(val_has_dimnames(typeof(x)))  === Val(true)
-@test @inferred(dimnames(x)) === d
-@test @inferred(dimnames(x')) === reverse(d)
-@test @inferred(dimnames(y')) === (static(:_), static(:x))
-@test @inferred(dimnames(PermutedDimsArray(x, (2, 1)))) === reverse(d)
-@test @inferred(dimnames(view(x, :, 1))) === (static(:x),)
-@test @inferred(dimnames(view(x, :, :, :))) === (static(:x),static(:y), static(:_))
-@test @inferred(dimnames(view(x, :, 1, :))) === (static(:x), static(:_))
-@test @inferred(dimnames(x, ArrayInterface.One())) === static(:x)
-@test @inferred(ArrayInterface.to_dims(x, d)) == dnums
-@test @inferred(ArrayInterface.to_dims(x, reverse(d))) == reverse(dnums)
-@test_throws ArgumentError ArrayInterface.to_dims(x, :z)
-
+@testset "dimnames" begin
+    d = (static(:x), static(:y))
+    x = NamedDimsWrapper{d}(ones(2,2));
+    y = NamedDimsWrapper{(:x,)}(ones(2));
+    dnums = ntuple(+, length(d))
+    @test @inferred(val_has_dimnames(x)) === Val(true)
+    @test @inferred(val_has_dimnames(typeof(x))) === Val(true)
+    @test @inferred(val_has_dimnames(typeof(view(x, :, 1, :)))) === Val(true)
+    @test @inferred(dimnames(x)) === d
+    @test @inferred(dimnames(x')) === reverse(d)
+    @test @inferred(dimnames(y')) === (static(:_), static(:x))
+    @test @inferred(dimnames(PermutedDimsArray(x, (2, 1)))) === reverse(d)
+    @test @inferred(dimnames(view(x, :, 1))) === (static(:x),)
+    @test @inferred(dimnames(view(x, :, :, :))) === (static(:x),static(:y), static(:_))
+    @test @inferred(dimnames(view(x, :, 1, :))) === (static(:x), static(:_))
+    @test @inferred(dimnames(x, ArrayInterface.One())) === static(:x)
+end
 
 @testset "to_dims" begin
     x = NamedDimsWrapper{(:x, :y)}(ones(2,2));
     y = NamedDimsWrapper{(:x, :y, :a, :b, :c, :d)}(ones(6));
+
+    @test @inferred(ArrayInterface.to_dims(x, :)) == Colon()
+    @test @inferred(ArrayInterface.to_dims(x, 1)) == 1
     @testset "small case" begin
+        @test @inferred(ArrayInterface.to_dims(x, (:x, :y))) == (1, 2)
+        @test @inferred(ArrayInterface.to_dims(x, (:y, :x))) == (2, 1)
         @test @inferred(ArrayInterface.to_dims(x, :x)) == 1
         @test @inferred(ArrayInterface.to_dims(x, :y)) == 2
         @test_throws ArgumentError ArrayInterface.to_dims(x, :z)  # not found
@@ -101,13 +112,18 @@ dnums = ntuple(+, length(d))
     end
 end
 
+@testset "methods accepting dimnames" begin
+    d = (static(:x), static(:y))
+    x = NamedDimsWrapper{d}(ones(2,2));
+    y = NamedDimsWrapper{(:x,)}(ones(2));
+    @test @inferred(size(x, :x)) == size(parent(x), 1)
+    @test @inferred(ArrayInterface.size(y')) == (1, size(parent(x), 1))
+    @test @inferred(axes(x, :x)) == axes(parent(x), 1)
+    @test strides(x, :x) == ArrayInterface.strides(parent(x))[1]
 
-@test @inferred(size(x, :x)) == size(parent(x), 1)
-@test @inferred(axes(x, :x)) == axes(parent(x), 1)
-@test strides(x, :x) == ArrayInterface.strides(parent(x))[1]
-
-x[x = 1] = [2, 3]
-@test @inferred(getindex(x, x = 1)) == [2, 3]
+    x[x = 1] = [2, 3]
+    @test @inferred(getindex(x, x = 1)) == [2, 3]
+end
 
 end
 

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -447,7 +447,7 @@ end
     @test @inferred(ArrayInterface.size(Sp2, StaticInt(1))) === 2
     @test @inferred(ArrayInterface.size(Sp2, StaticInt(2))) === StaticInt(3)
     @test @inferred(ArrayInterface.size(Sp2, StaticInt(3))) === StaticInt(2)
-    
+
     @test @inferred(ArrayInterface.size(M)) === (StaticInt(2), StaticInt(3), StaticInt(4))
     @test @inferred(ArrayInterface.size(Mp)) === (StaticInt(3), StaticInt(4))
     @test @inferred(ArrayInterface.size(Mp2)) === (StaticInt(2), 2)
@@ -468,7 +468,7 @@ end
     @test @inferred(ArrayInterface.known_size(Sp2, StaticInt(1))) === nothing
     @test @inferred(ArrayInterface.known_size(Sp2, StaticInt(2))) === 3
     @test @inferred(ArrayInterface.known_size(Sp2, StaticInt(3))) === 2
-    
+
     @test @inferred(ArrayInterface.known_size(M)) === (2, 3, 4)
     @test @inferred(ArrayInterface.known_size(Mp)) === (3, 4)
     @test @inferred(ArrayInterface.known_size(Mp2)) === (2, nothing)
@@ -519,7 +519,7 @@ end
     @test @inferred(ArrayInterface.offsets(S)) === (StaticInt(1), StaticInt(1), StaticInt(1))
     @test @inferred(ArrayInterface.offsets(Sp)) === (StaticInt(1), StaticInt(1), StaticInt(1))
     @test @inferred(ArrayInterface.offsets(Sp2)) === (StaticInt(1), StaticInt(1), StaticInt(1))
-    
+
     @test @inferred(ArrayInterface.offsets(M)) === (StaticInt(1), StaticInt(1), StaticInt(1))
     @test @inferred(ArrayInterface.offsets(Mp)) === (StaticInt(1), StaticInt(1))
     @test @inferred(ArrayInterface.offsets(Mp2)) === (StaticInt(1), StaticInt(1))
@@ -571,7 +571,7 @@ end
     @test ArrayInterface.known_length((1,)) == 1
     @test ArrayInterface.known_length((a=1,b=2)) == 2
     @test ArrayInterface.known_length([]) == nothing
-    
+
     x = view(SArray{Tuple{3,3,3}}(ones(3,3,3)), :, SOneTo(2), 2)
     @test @inferred(ArrayInterface.known_length(x)) == 6
     @test @inferred(ArrayInterface.known_length(x')) == 6

--- a/test/static.jl
+++ b/test/static.jl
@@ -1,5 +1,6 @@
 
 @testset "StaticInt" begin
+    @test StaticInt(UInt(8)) === StaticInt{8}()
     @test iszero(StaticInt(0))
     @test !iszero(StaticInt(1))
     @test !isone(StaticInt(0))
@@ -46,8 +47,8 @@
 end
 
 @testset "StaticBool" begin
-    t = True()
-    f = False()
+    t = static(static(true))
+    f = static(false)
 
     @test @inferred(StaticInt(t)) === StaticInt(1)
     @test @inferred(StaticInt(f)) === StaticInt(0)
@@ -60,6 +61,13 @@ end
     @test @inferred(+f) === StaticInt(0)
     @test @inferred(-t) === StaticInt(-1)
     @test @inferred(-f) === StaticInt(0)
+
+    @test @inferred(xor(true, f))
+    @test @inferred(xor(f, true))
+    @test @inferred(xor(f, f)) === f
+    @test @inferred(xor(f, t)) === t
+    @test @inferred(xor(t, f)) === t
+    @test @inferred(xor(t, t)) === f
 
     @test @inferred(|(true, f))
     @test @inferred(|(f, true))
@@ -138,5 +146,5 @@ end
     @test @inferred(IfElse.ifelse(f, x, y)) === y
 end
 
-
+@test_throws ErrorException static("a")
 


### PR DESCRIPTION
This doesn't completely fix #115, but it does take care of the problems with `Symbol`. I'll update that issue with what still needs to be worked on.

Although this commit changes how `dimnames` works and completely gets rid of a couple methods it shouldn't be breaking because none of these are actually part of the README and no packages should depend on them at this point.

I also moved `static` to the README because I think it's worth making part of the public API. I think it' more convenient than typing out the entirety of a static types name.