### PR TITLE
Fix `device`

### DIFF
--- a/src/ArrayInterface.jl
+++ b/src/ArrayInterface.jl
@@ -616,6 +616,7 @@ device(A) = device(typeof(A))
 device(::Type) = nothing
 device(::Type{<:Tuple}) = CPUIndex()
 device(::Type{T}) where {T<:Array} = CPUPointer()
+device(::Type{T}) where {T<:BitArray} = CPUPointer()
 device(::Type{T}) where {T<:AbstractArray} = CPUIndex()
 device(::Type{T}) where {T<:PermutedDimsArray} = device(parent_type(T))
 device(::Type{T}) where {T<:Transpose} = device(parent_type(T))

--- a/src/ArrayInterface.jl
+++ b/src/ArrayInterface.jl
@@ -616,7 +616,6 @@ device(A) = device(typeof(A))
 device(::Type) = nothing
 device(::Type{<:Tuple}) = CPUIndex()
 device(::Type{T}) where {T<:Array} = CPUPointer()
-device(::Type{T}) where {T<:BitArray} = CPUPointer()
 device(::Type{T}) where {T<:AbstractArray} = CPUIndex()
 device(::Type{T}) where {T<:PermutedDimsArray} = device(parent_type(T))
 device(::Type{T}) where {T<:Transpose} = device(parent_type(T))

--- a/src/ArrayInterface.jl
+++ b/src/ArrayInterface.jl
@@ -615,7 +615,6 @@ Otherwise, returns `nothing`.
 device(A) = device(typeof(A))
 device(::Type) = nothing
 device(::Type{<:Tuple}) = CPUIndex()
-# Relies on overloading for GPUArrays that have subtyped `StridedArray`.
 device(::Type{T}) where {T<:Array} = CPUPointer()
 device(::Type{T}) where {T<:AbstractArray} = CPUIndex()
 device(::Type{T}) where {T<:PermutedDimsArray} = device(parent_type(T))

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -296,6 +296,7 @@ struct Wrapper{T,N,P<:AbstractArray{T,N}} <: ArrayInterface.AbstractArray2{T,N}
 end
 ArrayInterface.parent_type(::Type{<:Wrapper{T,N,P}}) where {T,N,P} = P
 Base.parent(x::Wrapper) = x.parent
+ArrayInterface.device(::Type{T}) where {T<:Wrapper} = ArrayInterface.device(parent_type(T))
 
 using OffsetArrays
 @testset "Memory Layout" begin


### PR DESCRIPTION
Fixing `device` following discussion in #120. Default is now `CPUIndex` and no default for `StridedArray`. Instead, array types that work with `pointer` and define strides should explicitly define this

```julia
ArrayInterface.device(::Type{T}) where {T<:NewType} = device(parent_type(T))
```

This should also makes it so GPUArrays won't need to define `device` for all the `StridedArray` types because the proper `AbstractDevice` will be pulled from the original parent type if strides are defined.