### PR TITLE
ArrayInterfaceStaticArraysCore needs latest ArrayInterfaceCore

### DIFF
--- a/lib/ArrayInterfaceStaticArraysCore/Project.toml
+++ b/lib/ArrayInterfaceStaticArraysCore/Project.toml
@@ -10,7 +10,7 @@ StaticArraysCore = "1e83bf80-4336-4d27-bf5d-d5a4f845583c"
 
 [compat]
 Adapt = "3"
-ArrayInterfaceCore = "0.1.13"
+ArrayInterfaceCore = "0.1.22"
 StaticArraysCore = "1"
 julia = "1.6"
 


### PR DESCRIPTION
As is, the package resolver is likely to match the latest static arrays core with old array interface cores, causing `undefmatrix` not defined errors. @oscardssmith 