### PR TITLE
Minimal interface for index labels

### DIFF
--- a/docs/make.jl
+++ b/docs/make.jl
@@ -12,6 +12,7 @@ makedocs(;
         "sparsearrays.md",
         "tuples.md",
         "wrapping.md",
+        "index_labels.md",
     ]
 )
 

--- a/docs/src/index_labels.md
+++ b/docs/src/index_labels.md
@@ -1,0 +1,9 @@
+# Index Labels Interface
+
+The following ArrayInterface functions provide support for indices with labels.
+
+```@docs
+ArrayInterface.has_index_labels
+ArrayInterface.index_labels
+```
+

--- a/src/ArrayInterface.jl
+++ b/src/ArrayInterface.jl
@@ -1059,12 +1059,18 @@ each index along `dim` of `x`.
 $INDEX_LABELS_EXTENDED_HELP
 """
 function index_labels(x::T) where {T}
-    has_index_labels(T) || (@noinline; throw(ArgumentError("Objects of type $T do not support `index_labels`")))
-    is_forwarding_wrapper(T) || (@noinline; throw(ArgumentError("`has_index_labels($(T)) == true` but does not have `ArrayInterface.index_labels(::$T)` defined.")))
+    has_index_labels(T) || _throw_index_labels(T)
+    is_forwarding_wrapper(T) || _violated_index_label_interface(T)
     return index_labels(parent(x))
 end
 index_labels(x, dim::Integer) = index_labels(x)[Int(dim)]
 
+@noinline function _throw_index_labels(T::DataType)
+    throw(ArgumentError("Objects of type $T do not support `index_labels`"))
+end
+@noinline function _violated_index_label_interface(T::DataType)
+    throw(ArgumentError("`has_index_labels($(T)) == true` but does not have `ArrayInterface.index_labels(::$T)` defined."))
+end
 
 ## Extensions
 

--- a/src/ArrayInterface.jl
+++ b/src/ArrayInterface.jl
@@ -1023,6 +1023,29 @@ ensures_sorted(@nospecialize( T::Type{<:AbstractRange})) = true
 ensures_sorted(T::Type) = is_forwarding_wrapper(T) ? ensures_sorted(parent_type(T)) : false
 ensures_sorted(@nospecialize(x)) = ensures_sorted(typeof(x))
 
+"""
+    has_index_labels(T::Type) -> Bool
+
+Returns `true` if instances of `T` have labeled indices. Structures overloading this
+method are also responsible for defining [`ArrayInterface.index_labels`](@ref). 
+"""
+function has_index_labels(T::Type)
+    is_forwarding_wrapper(T) ? has_index_labels(parent_type(T)) : false
+end
+
+"""
+    index_labels(x)
+    index_labels(x, dim)
+
+Returns a tuple of labels assigned to each axis or a collection of labels corresponding to
+each index along `dim` of `x`. Default is to return `UnlabelledIndices(axes(x, dim))`.
+"""
+function index_labels(x::T) where {T}
+    has_index_labels(T) || (@noinline; throw(ArgumentError("Objects of type $T do not support `index_labels`")))
+    is_forwarding_wrapper(T) || (@noinline; throw(ArgumentError("`has_index_labels($(T)) == true` but does not have `ArrayInterface.index_labels(::$T)` defined.")))
+    return index_labels(parent(x))
+end
+
 ## Extensions
 
 import Requires

--- a/test/core.jl
+++ b/test/core.jl
@@ -7,6 +7,21 @@ using Random
 using SparseArrays
 using Test
 
+struct LabeledIndicesArray{T,N,P<:AbstractArray{T,N},L} <: AbstractArray{T,N}
+    parent::P
+    labels::L
+
+    LabeledIndicesArray(p::P, labels::L) where {P,L} = new{eltype(P),ndims(p),P,L}(p, labels)
+end
+ArrayInterface.is_forwarding_wrapper(::Type{<:LabeledIndicesArray}) = true
+Base.parent(x::LabeledIndicesArray) = getfield(x, :parent)
+ArrayInterface.parent_type(::Type{T}) where {P,T<:LabeledIndicesArray{<:Any,<:Any,P}} = P
+ArrayInterface.index_labels(x::LabeledIndicesArray) = getfield(x, :labels)
+ArrayInterface.has_index_labels(T::Type{<:LabeledIndicesArray}) = true
+ArrayInterface.is_forwarding_wrapper(::Type{<:LabeledIndicesArray}) = true
+Base.size(x::LabeledIndicesArray) = size(parent(x))
+Base.@propagate_inbounds Base.getindex(x::LabeledIndicesArray, inds...) = parent(x)[inds...]
+
 # ensure we are correctly parsing these
 ArrayInterface.@assume_effects :total foo(x::Bool) = x
 ArrayInterface.@assume_effects bar(x::Bool) = x
@@ -274,3 +289,21 @@ end
         end
     end
 end
+
+@testset "index_labels" begin
+    a = ones(2, 3)
+    lia = LabeledIndicesArray(a, ([:a, :b], ["x", "y", "z"]))
+
+    @test @inferred(ArrayInterface.has_index_labels(typeof(lia)))
+    @test !@inferred(ArrayInterface.has_index_labels(typeof(a)))
+
+    @test @inferred(ArrayInterface.index_labels(lia)) == lia.labels
+    @test ArrayInterface.index_labels(lia, 1) == lia.labels[1]
+    @test_throws ArgumentError ArrayInterface.index_labels(a)
+
+    # throw errors when interface isn't implemented correctly
+    struct IllegalLabelledIndices end
+    ArrayInterface.has_index_labels(::Type{IllegalLabelledIndices}) = true
+    @test_throws ArgumentError ArrayInterface.index_labels(IllegalLabelledIndices())
+end
+


### PR DESCRIPTION
This follows up on #328 but drastically reduces complexity. I'd like to punt the more complex stuff (default labels, looking up labels, etc.) to future work so we can actually take advantage of the [bike-shedding](https://discourse.julialang.org/t/commit-to-a-common-syntax-for-accessing-additional-index-mapping-information-on-axes/84988) that's already been done.