### PR TITLE
Add promote_eltype for CuArray / ROCArray / MtlArray

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,6 +1,6 @@
 name = "ArrayInterface"
 uuid = "4fba245c-0d91-5ea0-9b3e-6abc04ee57a9"
-version = "7.23.0"
+version = "7.24.0"
 
 [deps]
 Adapt = "79e6a3ab-5dfb-504d-930d-738a2a938a0e"

--- a/ext/ArrayInterfaceAMDGPUExt.jl
+++ b/ext/ArrayInterfaceAMDGPUExt.jl
@@ -12,4 +12,10 @@ end
 
 ArrayInterface.device(::Type{<:AMDGPU.ROCArray}) = ArrayInterface.GPU()
 
+function ArrayInterface.promote_eltype(
+        ::Type{<:AMDGPU.ROCArray{T, N, B}}, ::Type{T2}
+    ) where {T, N, B, T2}
+    return AMDGPU.ROCArray{promote_type(T, T2), N, B}
+end
+
 end # module

--- a/ext/ArrayInterfaceCUDAExt.jl
+++ b/ext/ArrayInterfaceCUDAExt.jl
@@ -13,4 +13,10 @@ end
 
 ArrayInterface.device(::Type{<:CUDA.CuArray}) = ArrayInterface.GPU()
 
+function ArrayInterface.promote_eltype(
+        ::Type{<:CUDA.CuArray{T, N, M}}, ::Type{T2}
+    ) where {T, N, M, T2}
+    return CUDA.CuArray{promote_type(T, T2), N, M}
+end
+
 end # module

--- a/ext/ArrayInterfaceMetalExt.jl
+++ b/ext/ArrayInterfaceMetalExt.jl
@@ -12,4 +12,10 @@ end
 
 ArrayInterface.device(::Type{<:Metal.MtlArray}) = ArrayInterface.GPU()
 
+function ArrayInterface.promote_eltype(
+        ::Type{<:Metal.MtlArray{T, N, S}}, ::Type{T2}
+    ) where {T, N, S, T2}
+    return Metal.MtlArray{promote_type(T, T2), N, S}
+end
+
 end # module


### PR DESCRIPTION
## Summary

- Adds `ArrayInterface.promote_eltype` methods for the three GPU array types, defined in their respective package extensions (`ArrayInterfaceCUDAExt`, `ArrayInterfaceAMDGPUExt`, `ArrayInterfaceMetalExt`).
- Each implementation swaps the element type via `promote_type(T, T2)` while preserving the array's other type parameters (memory kind `M` for `CuArray`, buffer type `B` for `ROCArray`, storage mode `S` for `MtlArray`).
- Bumps patch version `7.23.0` → `7.24.0`.

## Why

`ArrayInterface.promote_eltype` was only defined for `Array{T, N}` (with a "no generic fallback" note in its docstring), so downstream packages that pass GPU array types through `promote_eltype` hit a `MethodError`. Example from SciML/NonlinearSolve.jl#910 (`test/cuda_tests.jl:33 "GeneralizedFirstOrderAlgorithm"`) when deriving a Dual-eltype wrapper-signature type for a `CuArray{Float32}` state:

```
MethodError: no method matching promote_eltype(
    ::Type{CuArray{Float32, 1, CUDA.DeviceMemory}},
    ::Type{ForwardDiff.Dual{Tag{NonlinearSolveBase.NonlinearSolveTag, Float32}, Float32, 1}})
```

Adding the obvious eltype-swapping method in each GPU extension makes `promote_eltype` usable for GPU-array downstream code paths without forcing callers back onto the allocating `typeof(similar(a, T2))` pattern.

## Test plan

- [ ] CI passes (no GPU runners configured in this repo, so methods are verified by dispatch signature only; downstream NonlinearSolve.jl CUDA tests confirm the CuArray variant resolves correctly).

## Notes

- No changes to the generic `promote_eltype` contract — the "no generic fallback" docstring note still holds; this PR just adds three more concrete methods.
- Method signatures use \`<:CUDA.CuArray{T, N, M}\` (etc.) rather than the exact type to cover subtypes (e.g. \`DenseCuArray\`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)