### PR TITLE
`can_setindex` must be `false` for CUSPARSE arrays

### DIFF
--- a/ext/ArrayInterfaceCUDAExt.jl
+++ b/ext/ArrayInterfaceCUDAExt.jl
@@ -3,6 +3,7 @@ module ArrayInterfaceCUDAExt
 using ArrayInterface
 using CUDA
 using CUDA.CUSOLVER
+using CUDA.CUSPARSE
 using LinearAlgebra
 
 function ArrayInterface.lu_instance(A::CuMatrix{T}) where {T}
@@ -12,6 +13,17 @@ function ArrayInterface.lu_instance(A::CuMatrix{T}) where {T}
 end
 
 ArrayInterface.device(::Type{<:CUDA.CuArray}) = ArrayInterface.GPU()
+
+# CUSPARSE arrays implement no `setindex!` at all, so the `true` default is wrong
+# for them and callers guarding mutation with `can_setindex` hit a CanonicalIndexError.
+const CuSparseArray = Union{
+    CUSPARSE.CuSparseVector,
+    CUSPARSE.CuSparseMatrixCSC,
+    CUSPARSE.CuSparseMatrixCSR,
+    CUSPARSE.CuSparseMatrixBSR,
+    CUSPARSE.CuSparseMatrixCOO,
+}
+ArrayInterface.can_setindex(::Type{<:CuSparseArray}) = false
 
 function ArrayInterface.promote_eltype(
         ::Type{<:CUDA.CuArray{T, N, M}}, ::Type{T2}

--- a/test/gpu/cuda.jl
+++ b/test/gpu/cuda.jl
@@ -18,3 +18,11 @@ lu_sparse = lu!(lu_inst_sparse, A_sparse)
 #test that the resulting lu works
 b = CuVector([1f0, 1f0])
 @test CUDA.@allowscalar lu_sparse \ b == [1, 1]
+
+# CUSPARSE arrays have no `setindex!`, so `can_setindex` must not claim they do
+@test ArrayInterface.can_setindex(A_dense)
+@test !ArrayInterface.can_setindex(A_sparse)
+@test !ArrayInterface.can_setindex(CuSparseMatrixCSC(sparse(A_cpu)))
+@test !ArrayInterface.can_setindex(CuSparseMatrixCOO(sparse(A_cpu)))
+@test !ArrayInterface.can_setindex(CuSparseVector(sparsevec([1], [1.0f0], 2)))
+@test_throws CanonicalIndexError A_sparse[1, 2] = 1.0f0


### PR DESCRIPTION
cuSPARSE arrays implement no `setindex!` at all, but `can_setindex` falls back to `true`
for them, so callers that guard mutation with it crash instead of taking their
non-mutating path:

```julia
julia> A = CuSparseMatrixCSC(sparse(Float64[1 0; 0 1]));

julia> ArrayInterface.can_setindex(A)   # should be false
true

julia> A[1, 2] = 1.0
ERROR: CanonicalIndexError: setindex! not defined for CuSparseMatrixCSC{Float64, Int32}
```

This declares `can_setindex = false` for the cuSPARSE types in the CUDA extension, with a
test in `test/gpu/cuda.jl`. The AMDGPU/Metal sparse types might need the same; I left them
alone as I can't test them.