### PR TITLE
Add public same_sparsity_structure(A, B)

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,6 +1,6 @@
 name = "ArrayInterface"
 uuid = "4fba245c-0d91-5ea0-9b3e-6abc04ee57a9"
-version = "7.27.0"
+version = "7.28.0"
 
 [deps]
 Adapt = "79e6a3ab-5dfb-504d-930d-738a2a938a0e"

--- a/docs/src/sparsearrays.md
+++ b/docs/src/sparsearrays.md
@@ -11,6 +11,7 @@ These routines allow for improving sparse iteration and indexing.
 ArrayInterface.isstructured
 ArrayInterface.findstructralnz
 ArrayInterface.has_sparsestruct
+ArrayInterface.same_sparsity_structure
 ```
 
 ## Matrix Coloring

--- a/ext/ArrayInterfaceCUDAExt.jl
+++ b/ext/ArrayInterfaceCUDAExt.jl
@@ -25,6 +25,19 @@ const CuSparseArray = Union{
 }
 ArrayInterface.can_setindex(::Type{<:CuSparseArray}) = false
 
+# GPU CSC/CSR do not subtype `SparseArrays.AbstractSparseMatrixCSC`, so they need their own
+# structure comparison. The stored index arrays are `CuVector`s; `==` reduces on-device.
+function ArrayInterface.same_sparsity_structure(
+        A::CUSPARSE.CuSparseMatrixCSC, B::CUSPARSE.CuSparseMatrixCSC
+    )
+    size(A) == size(B) && A.colPtr == B.colPtr && A.rowVal == B.rowVal
+end
+function ArrayInterface.same_sparsity_structure(
+        A::CUSPARSE.CuSparseMatrixCSR, B::CUSPARSE.CuSparseMatrixCSR
+    )
+    size(A) == size(B) && A.rowPtr == B.rowPtr && A.colVal == B.colVal
+end
+
 function ArrayInterface.promote_eltype(
         ::Type{<:CUDA.CuArray{T, N, M}}, ::Type{T2}
     ) where {T, N, M, T2}

--- a/ext/ArrayInterfaceSparseArraysExt.jl
+++ b/ext/ArrayInterfaceSparseArraysExt.jl
@@ -1,8 +1,9 @@
 module ArrayInterfaceSparseArraysExt
 
-import ArrayInterface: buffer, has_sparsestruct, issingular, findstructralnz, bunchkaufman_instance, DEFAULT_CHOLESKY_PIVOT, cholesky_instance, ldlt_instance, lu_instance, qr_instance
+import ArrayInterface: buffer, has_sparsestruct, issingular, findstructralnz, same_sparsity_structure, bunchkaufman_instance, DEFAULT_CHOLESKY_PIVOT, cholesky_instance, ldlt_instance, lu_instance, qr_instance
 using ArrayInterface.LinearAlgebra
 using SparseArrays
+using SparseArrays: AbstractSparseMatrixCSC, getcolptr, rowvals
 
 buffer(x::SparseMatrixCSC) = getfield(x, :nzval)
 buffer(x::SparseVector) = getfield(x, :nzval)
@@ -12,6 +13,13 @@ issingular(A::AbstractSparseMatrix) = !issuccess(lu(A, check = false))
 function findstructralnz(x::SparseMatrixCSC)
     rowind, colind, _ = findnz(x)
     (rowind, colind)
+end
+
+# Compares the stored index arrays directly (no `findnz` allocation), so it is cheap
+# enough for per-iteration reuse checks. Covers any CPU CSC type implementing the
+# `getcolptr`/`rowvals` interface.
+function same_sparsity_structure(A::AbstractSparseMatrixCSC, B::AbstractSparseMatrixCSC)
+    Base.size(A) == Base.size(B) && getcolptr(A) == getcolptr(B) && rowvals(A) == rowvals(B)
 end
 
 function bunchkaufman_instance(A::SparseMatrixCSC{Tv, Ti}) where {Tv, Ti}

--- a/src/ArrayInterface.jl
+++ b/src/ArrayInterface.jl
@@ -356,26 +356,34 @@ Semantics by category:
   - Structured (`Diagonal`, `Bidiagonal`, `Tridiagonal`, `SymTridiagonal`) and sparse
     (`SparseMatrixCSC`, GPU CSC/CSR) matrices compare by their pattern — shape (plus
     `uplo`/format) or the stored index arrays (e.g. `colptr`/`rowval` for CSC).
-  - A pair from different structural categories (e.g. a structured matrix and a dense one,
-    or two different structured types) returns `false`: for the intended reuse use case a
-    layout is not reused across categories, so this is treated as "not the same structure"
-    rather than compared position-by-position.
+  - Two arrays whose base types differ (e.g. a structured matrix and a dense one, or two
+    different structured types) return `false`: a layout is not reused across categories,
+    so they are treated as "not the same structure".
+  - Two arrays of the *same* base type with no specialized method are **unknown**, not
+    `false`: rather than fabricate an answer, a `MethodError` is thrown so the type can
+    define its own method. (`has_sparsestruct` can be used to check applicability first.)
 
 Unlike `findstructralnz`, this performs no allocation on its fast paths, so it is suitable
 for use in hot loops (for example, deciding per Jacobian evaluation whether a sparse
 `jac_prototype`'s structure needs rebuilding).
 """
-same_sparsity_structure(A::AbstractArray, B::AbstractArray) = false
+function same_sparsity_structure(A::AbstractArray, B::AbstractArray)
+    # Same base type but no specialized method: we genuinely do not know -- error rather
+    # than return a possibly-wrong `false`. Different base types cannot share a structural
+    # category, so those are `false`.
+    parameterless_type(A) === parameterless_type(B) &&
+        throw(MethodError(same_sparsity_structure, (A, B)))
+    return false
+end
 same_sparsity_structure(A::DenseArray, B::DenseArray) = Base.size(A) == Base.size(B)
 same_sparsity_structure(A::Diagonal, B::Diagonal) = Base.size(A) == Base.size(B)
 function same_sparsity_structure(A::Bidiagonal, B::Bidiagonal)
     Base.size(A) == Base.size(B) && A.uplo == B.uplo
 end
-# Same concrete banded type (both Tridiagonal or both SymTridiagonal); a mixed pair falls
-# through to the category fallback (`false`).
-function same_sparsity_structure(A::T, B::T) where {T <: Union{Tridiagonal, SymTridiagonal}}
-    Base.size(A) == Base.size(B)
-end
+# Base-type methods (not `A::T, B::T`) so differing type parameters, e.g.
+# `Tridiagonal{Float64}` vs `Tridiagonal{Int}`, still compare as the same structure.
+same_sparsity_structure(A::Tridiagonal, B::Tridiagonal) = Base.size(A) == Base.size(B)
+same_sparsity_structure(A::SymTridiagonal, B::SymTridiagonal) = Base.size(A) == Base.size(B)
 
 abstract type ColoringAlgorithm end
 

--- a/src/ArrayInterface.jl
+++ b/src/ArrayInterface.jl
@@ -344,30 +344,28 @@ end
 """
     same_sparsity_structure(A, B) -> Bool
 
-Return `true` when `A` and `B` are known to store their nonzeros in exactly the same
-structural positions, i.e. they share an identical sparsity pattern (and shape). This is
-the condition under which values may be written into `B` reusing `A`'s stored layout (or a
-cached symbolic factorization of `A` reused for `B`) without rebuilding the structure.
+Return `true` when `A` and `B` store their nonzeros in exactly the same structural
+positions, i.e. they share an identical sparsity pattern (and shape). This is the condition
+under which values may be written into `B` reusing `A`'s stored layout (or a cached symbolic
+factorization of `A` reused for `B`) without rebuilding the structure.
 
-The check is *conservative*: it returns `true` only when identical structure can be
-established cheaply for the given types, and `false` otherwise. A `false` result therefore
-does not prove the structures differ -- it means equality could not be confirmed cheaply, so
-a caller should fall back to reconstructing the structure. The generic fallback returns
-`false`; specialized methods are provided for the sparse and structured matrix types for
-which the pattern is decided by shape (plus `uplo`/format) or by comparing the stored
-index arrays (e.g. `colptr`/`rowval` for CSC).
+Defined for the sparse and structured matrix types whose pattern is decided by shape (plus
+`uplo`/format) or by comparing the stored index arrays (e.g. `colptr`/`rowval` for CSC).
+There is deliberately no generic fallback: an unsupported argument pair throws a
+`MethodError` rather than silently returning a (possibly wrong) default, so callers get a
+positive `true`/`false` answer or a clear signal that the type needs a method. `has_sparsestruct`
+can be used to check applicability first.
 
 Unlike `findstructralnz`, this performs no allocation on its fast paths, so it is suitable
 for use in hot loops (for example, deciding per Jacobian evaluation whether a sparse
 `jac_prototype`'s structure needs rebuilding).
 """
-same_sparsity_structure(A, B) = false
+function same_sparsity_structure end
 same_sparsity_structure(A::Diagonal, B::Diagonal) = Base.size(A) == Base.size(B)
 function same_sparsity_structure(A::Bidiagonal, B::Bidiagonal)
     Base.size(A) == Base.size(B) && A.uplo == B.uplo
 end
-# Same concrete banded type (both Tridiagonal or both SymTridiagonal); a mixed pair falls
-# through to the conservative generic `false`.
+# Same concrete banded type (both Tridiagonal or both SymTridiagonal).
 function same_sparsity_structure(A::T, B::T) where {T <: Union{Tridiagonal, SymTridiagonal}}
     Base.size(A) == Base.size(B)
 end

--- a/src/ArrayInterface.jl
+++ b/src/ArrayInterface.jl
@@ -341,6 +341,37 @@ function findstructralnz(x::Union{Tridiagonal, SymTridiagonal})
     (rowind, colind)
 end
 
+"""
+    same_sparsity_structure(A, B) -> Bool
+
+Return `true` when `A` and `B` are known to store their nonzeros in exactly the same
+structural positions, i.e. they share an identical sparsity pattern (and shape). This is
+the condition under which values may be written into `B` reusing `A`'s stored layout (or a
+cached symbolic factorization of `A` reused for `B`) without rebuilding the structure.
+
+The check is *conservative*: it returns `true` only when identical structure can be
+established cheaply for the given types, and `false` otherwise. A `false` result therefore
+does not prove the structures differ -- it means equality could not be confirmed cheaply, so
+a caller should fall back to reconstructing the structure. The generic fallback returns
+`false`; specialized methods are provided for the sparse and structured matrix types for
+which the pattern is decided by shape (plus `uplo`/format) or by comparing the stored
+index arrays (e.g. `colptr`/`rowval` for CSC).
+
+Unlike `findstructralnz`, this performs no allocation on its fast paths, so it is suitable
+for use in hot loops (for example, deciding per Jacobian evaluation whether a sparse
+`jac_prototype`'s structure needs rebuilding).
+"""
+same_sparsity_structure(A, B) = false
+same_sparsity_structure(A::Diagonal, B::Diagonal) = Base.size(A) == Base.size(B)
+function same_sparsity_structure(A::Bidiagonal, B::Bidiagonal)
+    Base.size(A) == Base.size(B) && A.uplo == B.uplo
+end
+# Same concrete banded type (both Tridiagonal or both SymTridiagonal); a mixed pair falls
+# through to the conservative generic `false`.
+function same_sparsity_structure(A::T, B::T) where {T <: Union{Tridiagonal, SymTridiagonal}}
+    Base.size(A) == Base.size(B)
+end
+
 abstract type ColoringAlgorithm end
 
 """
@@ -1005,8 +1036,8 @@ end
         :cholesky_instance, :ldlt_instance, :lu_instance, :qr_instance,
         :svd_instance,
         # sparse arrays
-        :isstructured, :findstructralnz, :has_sparsestruct, :fast_matrix_colors,
-        :matrix_colors,
+        :isstructured, :findstructralnz, :has_sparsestruct, :same_sparsity_structure,
+        :fast_matrix_colors, :matrix_colors,
         # wrapping
         :is_forwarding_wrapper, :buffer, :parent_type,
         # tuples

--- a/src/ArrayInterface.jl
+++ b/src/ArrayInterface.jl
@@ -349,23 +349,30 @@ positions, i.e. they share an identical sparsity pattern (and shape). This is th
 under which values may be written into `B` reusing `A`'s stored layout (or a cached symbolic
 factorization of `A` reused for `B`) without rebuilding the structure.
 
-Defined for the sparse and structured matrix types whose pattern is decided by shape (plus
-`uplo`/format) or by comparing the stored index arrays (e.g. `colptr`/`rowval` for CSC).
-There is deliberately no generic fallback: an unsupported argument pair throws a
-`MethodError` rather than silently returning a (possibly wrong) default, so callers get a
-positive `true`/`false` answer or a clear signal that the type needs a method. `has_sparsestruct`
-can be used to check applicability first.
+Semantics by category:
+
+  - Dense arrays store every position, so two of them share a structure exactly when they
+    have the same shape.
+  - Structured (`Diagonal`, `Bidiagonal`, `Tridiagonal`, `SymTridiagonal`) and sparse
+    (`SparseMatrixCSC`, GPU CSC/CSR) matrices compare by their pattern — shape (plus
+    `uplo`/format) or the stored index arrays (e.g. `colptr`/`rowval` for CSC).
+  - A pair from different structural categories (e.g. a structured matrix and a dense one,
+    or two different structured types) returns `false`: for the intended reuse use case a
+    layout is not reused across categories, so this is treated as "not the same structure"
+    rather than compared position-by-position.
 
 Unlike `findstructralnz`, this performs no allocation on its fast paths, so it is suitable
 for use in hot loops (for example, deciding per Jacobian evaluation whether a sparse
 `jac_prototype`'s structure needs rebuilding).
 """
-function same_sparsity_structure end
+same_sparsity_structure(A::AbstractArray, B::AbstractArray) = false
+same_sparsity_structure(A::DenseArray, B::DenseArray) = Base.size(A) == Base.size(B)
 same_sparsity_structure(A::Diagonal, B::Diagonal) = Base.size(A) == Base.size(B)
 function same_sparsity_structure(A::Bidiagonal, B::Bidiagonal)
     Base.size(A) == Base.size(B) && A.uplo == B.uplo
 end
-# Same concrete banded type (both Tridiagonal or both SymTridiagonal).
+# Same concrete banded type (both Tridiagonal or both SymTridiagonal); a mixed pair falls
+# through to the category fallback (`false`).
 function same_sparsity_structure(A::T, B::T) where {T <: Union{Tridiagonal, SymTridiagonal}}
     Base.size(A) == Base.size(B)
 end

--- a/test/core.jl
+++ b/test/core.jl
@@ -228,10 +228,15 @@ end
     @test !sss(Tridiagonal([1,2],[1,2,3],[4,5]), Tridiagonal([1],[1,2],[4]))
     @test sss(SymTridiagonal([1,2,3],[4,5]), SymTridiagonal([6,7,8],[9,1]))
 
-    # no generic fallback: unsupported / mixed-type pairs error rather than silently
-    # returning a possibly-wrong default
-    @test_throws MethodError sss(Diagonal([1,2,3]), Bidiagonal([1,2,3],[7,8],:U))
-    @test_throws MethodError sss(rand(3,3), rand(3,3))
+    # dense arrays: every position is structural, so same shape ⇒ same structure
+    @test sss(rand(3,3), rand(3,3))
+    @test !sss(rand(3,3), rand(3,2))
+    @test sss(rand(4), rand(4))
+
+    # different structural categories ⇒ false (not compared position-by-position)
+    @test !sss(Diagonal([1,2,3]), Bidiagonal([1,2,3],[7,8],:U))
+    @test !sss(Diagonal([1,2,3]), rand(3,3))
+    @test !sss(Tridiagonal([1,2],[1,2,3],[4,5]), SymTridiagonal([1,2,3],[4,5]))
 
     # sparse CSC: compares the stored index arrays
     A = sparse([1,2,3],[1,2,3],[1.0,2.0,3.0])

--- a/test/core.jl
+++ b/test/core.jl
@@ -228,9 +228,10 @@ end
     @test !sss(Tridiagonal([1,2],[1,2,3],[4,5]), Tridiagonal([1],[1,2],[4]))
     @test sss(SymTridiagonal([1,2,3],[4,5]), SymTridiagonal([6,7,8],[9,1]))
 
-    # different / mixed types fall through to the conservative generic `false`
-    @test !sss(Diagonal([1,2,3]), Bidiagonal([1,2,3],[7,8],:U))
-    @test !sss(rand(3,3), rand(3,3))
+    # no generic fallback: unsupported / mixed-type pairs error rather than silently
+    # returning a possibly-wrong default
+    @test_throws MethodError sss(Diagonal([1,2,3]), Bidiagonal([1,2,3],[7,8],:U))
+    @test_throws MethodError sss(rand(3,3), rand(3,3))
 
     # sparse CSC: compares the stored index arrays
     A = sparse([1,2,3],[1,2,3],[1.0,2.0,3.0])

--- a/test/core.jl
+++ b/test/core.jl
@@ -228,15 +228,21 @@ end
     @test !sss(Tridiagonal([1,2],[1,2,3],[4,5]), Tridiagonal([1],[1,2],[4]))
     @test sss(SymTridiagonal([1,2,3],[4,5]), SymTridiagonal([6,7,8],[9,1]))
 
+    # same base type, differing type parameters ⇒ still the same structure
+    @test sss(Tridiagonal([1,2],[1,2,3],[4,5]), Tridiagonal([1.0,2],[1.0,2,3],[4.0,5]))
+
     # dense arrays: every position is structural, so same shape ⇒ same structure
     @test sss(rand(3,3), rand(3,3))
     @test !sss(rand(3,3), rand(3,2))
     @test sss(rand(4), rand(4))
 
-    # different structural categories ⇒ false (not compared position-by-position)
+    # different base types ⇒ false (not compared position-by-position)
     @test !sss(Diagonal([1,2,3]), Bidiagonal([1,2,3],[7,8],:U))
     @test !sss(Diagonal([1,2,3]), rand(3,3))
     @test !sss(Tridiagonal([1,2],[1,2,3],[4,5]), SymTridiagonal([1,2,3],[4,5]))
+
+    # same base type but no specialized method ⇒ unknown, error rather than fabricate false
+    @test_throws MethodError sss(UpperTriangular(rand(3,3)), UpperTriangular(rand(3,3)))
 
     # sparse CSC: compares the stored index arrays
     A = sparse([1,2,3],[1,2,3],[1.0,2.0,3.0])

--- a/test/core.jl
+++ b/test/core.jl
@@ -216,6 +216,32 @@ end
     @test [STri[rowind[i],colind[i]] for i in 1:length(rowind)]==[1,2,3,4,5,6,7,5,6,7]
 end
 
+@testset "same_sparsity_structure" begin
+    sss = ArrayInterface.same_sparsity_structure
+
+    # structured matrices: pattern is fixed by shape (plus uplo)
+    @test sss(Diagonal([1,2,3]), Diagonal([4,5,6]))
+    @test !sss(Diagonal([1,2,3]), Diagonal([4,5]))
+    @test sss(Bidiagonal([1,2,3],[7,8],:U), Bidiagonal([4,5,6],[9,1],:U))
+    @test !sss(Bidiagonal([1,2,3],[7,8],:U), Bidiagonal([4,5,6],[9,1],:L))
+    @test sss(Tridiagonal([1,2],[1,2,3],[4,5]), Tridiagonal([6,7],[8,9,1],[2,3]))
+    @test !sss(Tridiagonal([1,2],[1,2,3],[4,5]), Tridiagonal([1],[1,2],[4]))
+    @test sss(SymTridiagonal([1,2,3],[4,5]), SymTridiagonal([6,7,8],[9,1]))
+
+    # different / mixed types fall through to the conservative generic `false`
+    @test !sss(Diagonal([1,2,3]), Bidiagonal([1,2,3],[7,8],:U))
+    @test !sss(rand(3,3), rand(3,3))
+
+    # sparse CSC: compares the stored index arrays
+    A = sparse([1,2,3],[1,2,3],[1.0,2.0,3.0])
+    B = sparse([1,2,3],[1,2,3],[4.0,5.0,6.0])   # same pattern, different values
+    C = sparse([1,2,3],[1,2,1],[4.0,5.0,6.0])   # different pattern
+    @test sss(A, B)
+    @test !sss(A, C)
+    @test sss(A, similar(A))                    # `similar` preserves the pattern
+    @test !sss(A, sparse([1,2],[1,2],[1.0,2.0]))  # different size
+end
+
 @testset "ndims_index" begin
     @test @inferred(ArrayInterface.ndims_index(CartesianIndices(()))) == 1
     @test @inferred(ArrayInterface.ndims_index(trues(2, 2))) == 2


### PR DESCRIPTION
> **Draft — please ignore until reviewed by @ChrisRackauckas.**

## What

Adds a public, documented `same_sparsity_structure(A, B) -> Bool`: an allocation-free query that returns `true` when `A` and `B` store their nonzeros in exactly the same structural positions (same pattern and shape). That's the condition under which a preallocated sparse structure — or a cached symbolic factorization — can be reused for a values-only update without rebuilding the structure.

## Why

This check is currently reinvented in several places:

- LinearSolve.jl's internal `pattern_changed(fact, A)` (colptr/rowval comparison, run on every sparse solve, with GPU methods) — but it's not public and is shaped as *factorization-vs-matrix*.
- A local helper in OrdinaryDiffEq's `calc_J!` (SciML/OrdinaryDiffEq.jl#3980) guarding a per-Jacobian-eval sparse-structure rebuild.

ArrayInterface already owns the generic sparse-structure interface (`has_sparsestruct`, `findstructralnz`), so the matrix-vs-matrix structural-equality query belongs here. Unlike `findstructralnz` (which allocates `(rowind, colind)` via `findnz`), this allocates nothing on its fast paths, so it's usable in hot loops.

## Semantics

- **Dense arrays** store every position → same structure iff same shape.
- **Structured / sparse** matrices compare by pattern: shape (plus `uplo`/format) for `Diagonal`/`Bidiagonal`/`Tridiagonal`/`SymTridiagonal`; stored index arrays (`colptr`/`rowval` and GPU equivalents) for CSC/CSR. These dispatch on the **base type**, so differing type parameters (e.g. `Tridiagonal{Float64}` vs `Tridiagonal{Int}`) still compare as the same structure.
- **Different base types** (a structured matrix vs a dense one, or two different structured types) → `false`: a layout isn't reused across categories.
- **Same base type, no specialized method** → **`MethodError`**, not `false`. We don't fabricate an answer for a type we haven't been taught about (e.g. two `UpperTriangular`, which *do* share a structure); the type should define its own method. `has_sparsestruct` can gate applicability.

This avoids the two failure modes of a naive `f(A,B) = false` catch-all: reporting identical *dense* matrices as differing, and silently guessing `false` for a same-type pair whose structure it can't actually determine.

## Methods

- `AbstractArray` fallback → different base type `false`, same base type `MethodError`; `DenseArray` → shape
- `Diagonal` / `Bidiagonal` (with `uplo`) / `Tridiagonal` / `SymTridiagonal` — by shape (core)
- `AbstractSparseMatrixCSC` — via `getcolptr`/`rowvals` (SparseArrays ext)
- `CuSparseMatrixCSC` / `CuSparseMatrixCSR` — via their device index arrays (CUDA ext)

## Validation

- [x] `public` declaration + docstring + `docs/src/sparsearrays.md` entry (public and documented together)
- [x] Tests (`test/core.jl`): dense same/diff-shape/vector, structured same + cross-eltype, different-base-type → false, same-base-no-method → `@test_throws MethodError`, CSC same/different/`similar`/size
- [x] Full `GROUP=Core` suite passes locally (214/214); fast paths confirmed allocation-free (`@allocated == 0` for CSC / Diagonal / dense in a function barrier)
- [x] Minor version bump 7.27.0 → 7.28.0 (additive public API)
- [ ] GPU (CUDA CSC/CSR) methods are correct-by-construction against the CUSPARSE field/interface but **not locally tested** (no GPU here) — rely on the repo's GPU CI

Note: `AbstractGPUSparseMatrixCSC` does not subtype `SparseArrays.AbstractSparseMatrixCSC`, so GPU CSC needs the explicit CUDA-ext method rather than being covered by the SparseArrays one. A future GPUArrays-level method could cover CUDA/AMDGPU/Metal generically via the shared `getcolptr`/`rowvals` interface; I kept this to the existing per-backend pattern to avoid a new weakdep.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01LWooL8qipuUf7nTrDUUzqY
