### PR TITLE
Preserve tracked array wrappers in restructure

### DIFF
--- a/ext/ArrayInterfaceReverseDiffExt.jl
+++ b/ext/ArrayInterfaceReverseDiffExt.jl
@@ -15,5 +15,13 @@ end
 function ArrayInterface.restructure(x::Array, y::ReverseDiff.TrackedArray)
     reshape(y, Base.size(x)...)
 end
+function ArrayInterface.restructure(x::ReverseDiff.TrackedArray, y::ReverseDiff.TrackedArray)
+    reshape(y, Base.size(x)...)
+end
+function ArrayInterface.restructure(
+        x::ReverseDiff.TrackedArray, y::AbstractArray{<:ReverseDiff.TrackedReal}
+)
+    reshape(ArrayInterface.aos_to_soa(y), Base.size(x)...)
+end
 
 end # module

--- a/ext/ArrayInterfaceTrackerExt.jl
+++ b/ext/ArrayInterfaceTrackerExt.jl
@@ -7,10 +7,20 @@ ArrayInterface.ismutable(::Type{<:Tracker.TrackedArray}) = false
 ArrayInterface.ismutable(T::Type{<:Tracker.TrackedReal}) = false
 ArrayInterface.can_setindex(::Type{<:Tracker.TrackedArray}) = false
 ArrayInterface.fast_scalar_indexing(::Type{<:Tracker.TrackedArray}) = false
-ArrayInterface.aos_to_soa(x::AbstractArray{<:Tracker.TrackedReal,N}) where {N} = Tracker.collect(x)
+function ArrayInterface.aos_to_soa(x::AbstractArray{<:Tracker.TrackedReal, N}) where {N}
+    Tracker.collect(x)
+end
 
 function ArrayInterface.restructure(x::Array, y::Tracker.TrackedArray)
     reshape(y, Base.size(x)...)
+end
+function ArrayInterface.restructure(x::Tracker.TrackedArray, y::Tracker.TrackedArray)
+    reshape(y, Base.size(x)...)
+end
+function ArrayInterface.restructure(
+        x::Tracker.TrackedArray, y::AbstractArray{<:Tracker.TrackedReal}
+)
+    reshape(ArrayInterface.aos_to_soa(y), Base.size(x)...)
 end
 function ArrayInterface.restructure(x::Array, y::Array{<:Tracker.TrackedReal})
     reshape(y, Base.size(x)...)

--- a/test/ad.jl
+++ b/test/ad.jl
@@ -4,38 +4,50 @@ x = ReverseDiff.track([4.0])
 x = reshape([ReverseDiff.track(rand(1, 1, 1))[1]], 1, 1, 1)
 @test ArrayInterface.aos_to_soa(x) isa ReverseDiff.TrackedArray
 @test ndims(ArrayInterface.aos_to_soa(x)) == 3
-x = reduce(vcat, ReverseDiff.track([4.0,4.0]))
+x = reduce(vcat, ReverseDiff.track([4.0, 4.0]))
 @test ArrayInterface.aos_to_soa(x) isa ReverseDiff.TrackedArray
 x = [ReverseDiff.track([4.0])[1]]
 @test ArrayInterface.aos_to_soa(x) isa ReverseDiff.TrackedArray
-x = reduce(vcat, ReverseDiff.track([4.0,4.0]))
-x = [x[1],x[2]]
+x = reduce(vcat, ReverseDiff.track([4.0, 4.0]))
+x = [x[1], x[2]]
 @test ArrayInterface.aos_to_soa(x) isa ReverseDiff.TrackedArray
 
 x = Tracker.TrackedArray([4.0])
 @test ArrayInterface.aos_to_soa(x) isa Tracker.TrackedArray
 x = [Tracker.TrackedArray([4.0])[1]]
 @test ArrayInterface.aos_to_soa(x) isa Tracker.TrackedArray
-x = Tracker.TrackedArray([4.0,4.0])
+x = Tracker.TrackedArray([4.0, 4.0])
 @test ArrayInterface.aos_to_soa(x) isa Tracker.TrackedArray
-x = reduce(vcat, Tracker.TrackedArray([4.0,4.0]))
-x = [x[1],x[2]]
+x = reduce(vcat, Tracker.TrackedArray([4.0, 4.0]))
+x = [x[1], x[2]]
 @test ArrayInterface.aos_to_soa(x) isa Tracker.TrackedArray
 
 x = rand(4)
-y = Tracker.TrackedReal.(rand(2,2))
+y = Tracker.TrackedReal.(rand(2, 2))
 @test ArrayInterface.restructure(x, y) isa Array
 @test eltype(ArrayInterface.restructure(x, y)) <: Tracker.TrackedReal
 @test size(ArrayInterface.restructure(x, y)) == (4,)
-y = Tracker.TrackedArray(rand(2,2))
+y = Tracker.TrackedArray(rand(2, 2))
+@test ArrayInterface.restructure(x, y) isa Tracker.TrackedArray
+@test size(ArrayInterface.restructure(x, y)) == (4,)
+x = Tracker.TrackedArray(rand(4))
+@test ArrayInterface.restructure(x, y) isa Tracker.TrackedArray
+@test size(ArrayInterface.restructure(x, y)) == (4,)
+y = Tracker.TrackedReal.(rand(2, 2))
 @test ArrayInterface.restructure(x, y) isa Tracker.TrackedArray
 @test size(ArrayInterface.restructure(x, y)) == (4,)
 
 x = rand(4)
-y = ReverseDiff.track(rand(2,2))
+y = ReverseDiff.track(rand(2, 2))
 @test ArrayInterface.restructure(x, y) isa ReverseDiff.TrackedArray
 @test size(ArrayInterface.restructure(x, y)) == (4,)
-y = ReverseDiff.track.(rand(2,2))
+x = ReverseDiff.track(rand(4))
+@test ArrayInterface.restructure(x, y) isa ReverseDiff.TrackedArray
+@test size(ArrayInterface.restructure(x, y)) == (4,)
+y = ReverseDiff.track.(rand(2, 2))
+@test ArrayInterface.restructure(x, y) isa ReverseDiff.TrackedArray
+@test size(ArrayInterface.restructure(x, y)) == (4,)
+x = rand(4)
 @test ArrayInterface.restructure(x, y) isa Array
 @test eltype(ArrayInterface.restructure(x, y)) <: ReverseDiff.TrackedReal
 @test size(ArrayInterface.restructure(x, y)) == (4,)


### PR DESCRIPTION
> Ignore this PR until it has been reviewed by @ChrisRackauckas.

## Summary

- Preserve ReverseDiff and Tracker tracked-array wrappers when the restructure template is tracked.
- Convert arrays of tracked scalars back to their tracked array representation before reshaping.
- Cover tracked-array and array-of-tracked-scalars inputs in the AD integration tests.

## Why

`ArrayInterface.restructure(tracked_template, tracked_values)` currently falls through to the generic implementation. For an array of `ReverseDiff.TrackedReal` values, that produces a plain vector, so a downstream Rosenbrock stage changes from `ReverseDiff.TrackedArray` to `Vector{TrackedReal}` and cannot be assigned to the typed stage vector.

This was exposed by the SciMLSensitivity Core1 `BouncingBall ODE` test on clean current masters after the OrdinaryDiffEq LinearSolve 5 update. The fix belongs in the public `ArrayInterface.restructure` extensions rather than in an OrdinaryDiffEq workaround.

## Investigation process

1. Reproduced the clean-master failure under ReverseDiff, Tracker, and Zygote outer backends.
2. Isolated the failing value as `Vector{ReverseDiff.TrackedReal{..., Nothing}}` and confirmed the generic restructure stripped the wrapper.
3. Rejected a downstream `_restructure_state` fallback after it failed the exact solve.
4. Verified that `aos_to_soa` plus `reshape` preserves the tracked wrapper and gradient, then implemented that behavior in the owner extensions.
5. Ran the configured JuliaFormatter on the touched files.

## Local validation

- `GROUP=Core julia +1.10 --project=. -e "using Pkg; Pkg.test()"`
  - BandedMatrices 21/21
  - BlockBandedMatrices 8/8
  - Core 221/221
  - AD Integration 28/28
  - StaticArrays 39/39
  - ChainRules 20/20
  - FillArrays 7/7
  - process result: `Testing ArrayInterface tests passed`
- Focused stage probe preserved the wrapper through restructure, scalar multiplication, and typed stage assignment; ReverseDiff gradient `[2.0, 2.0]`.
- Unchanged Rosenbrock23 plus SciMLSensitivity BouncingBall reproduction returned the stable repeated ReverseDiff gradient `[26.96250030687455, 0.0]`.
- Original ForwardDiff/FiniteDiff reference plus ReverseDiff, Tracker, and Zygote matrix: 4/4 passed in 38.2 seconds.