### PR TITLE
Build the GPU lu_instance directly instead of calling lu

### DIFF
--- a/ext/ArrayInterfaceGPUArraysCoreExt.jl
+++ b/ext/ArrayInterfaceGPUArraysCoreExt.jl
@@ -2,7 +2,7 @@ module ArrayInterfaceGPUArraysCoreExt
 
 using Adapt
 using ArrayInterface
-using LinearAlgebra: lu
+import LinearAlgebra
 import GPUArraysCore
 
 ArrayInterface.fast_scalar_indexing(::Type{<:GPUArraysCore.AbstractGPUArray}) = false
@@ -19,8 +19,16 @@ function ArrayInterface.restructure(x::GPUArraysCore.AbstractGPUArray, y)
     reshape(Adapt.adapt(ArrayInterface.parameterless_type(x), y), Base.size(x)...)
 end
 
+# Build the `LU` directly rather than calling `lu` on an adapted array, matching the CPU
+# methods in ArrayInterface.jl. Going through `lu` only works for backends that define their
+# own, so it breaks on JLArrays (which downstream packages use to test GPU paths without a
+# GPU) and on Metal, see #501 and #467.
 function ArrayInterface.lu_instance(A::GPUArraysCore.AbstractGPUMatrix{T}) where {T}
-    lu(Adapt.adapt(ArrayInterface.parameterless_type(A), ones(T, 0, 0)))
+    noUnitT = typeof(zero(T))
+    luT = LinearAlgebra.lutype(noUnitT)
+    ipiv = similar(A, LinearAlgebra.BlasInt, 0)
+    info = zero(LinearAlgebra.BlasInt)
+    return LinearAlgebra.LU{luT}(similar(A, 0, 0), ipiv, info)
 end
 
 # Doesn't do much, but makes a gigantic change to the dependency chain.


### PR DESCRIPTION
Fixes #501.

`lu_instance` for GPU matrices builds the instance by calling `lu` on an adapted 0x0 array,
which only works for backends that define their own `lu`. JLArrays does not, so it falls
through to LinearAlgebra's generic path and dies:

```julia
using JLArrays, ArrayInterface
ArrayInterface.lu_instance(jl(ones(3, 3)))
# ERROR: Illegal conversion of a JLArray to a Ptr
```

There is no size that works, `lu(jl(ones(0,0)))` hits LAPACK `getrf!` and `lu(jl(ones(3,3)))`
hits "Scalar indexing is disallowed", so routing through `lu` is the problem rather than the
0x0.

This builds the `LU` directly, the same way the `Matrix`, `Symmetric` and
`Tridiagonal`/`Diagonal`/`SymTridiagonal` methods already do in `ArrayInterface.jl`, so no
backend `lu` is needed. After:

```julia
ArrayInterface.lu_instance(jl(ones(3, 3)))
# LU{Float64, JLArray{Float64, 2}, JLArray{Int64, 1}}
```

which mirrors the CPU result `LU{Float64, Matrix{Float64}, Vector{Int64}}`.

It matters downstream because JLArrays is what packages use to exercise GPU code paths without
a GPU. OrdinaryDiffEq's GPU autodiff test is failing through this on Julia 1, lts and pre right
now, and #467 reported the same shape for Metal.

Worth checking before merge: I only have JLArrays here, no CUDA/AMDGPU/Metal, so I could not
confirm the `ipiv` element type matches what those backends' own `lu` returns. The CPU methods
all use `BlasInt` and I followed them. If a backend's `lu` returns `Int32` there, this changes
the instance type for it.
